### PR TITLE
firebase-hosting-*.yml scripts updated - forced node v20

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # Forcing Node 20 bypasses the recent HTTP keep-alive bug
       - run: npm install --legacy-peer-deps && echo '-----Install Done 👌-----' && npm run build && echo '-----Build Done 👌-----'
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # Forcing Node 20 bypasses the recent HTTP keep-alive bug
       - run: npm i --legacy-peer-deps && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
> The issue you are encountering is due to a known bug introduced in recent Node.js updates (specifically affecting Node versions like v24.17.0+ and v22.23.0+).

> A change in Node's HTTP/TLS socket reuse and keep-alive connection pooling causes it to prematurely drop connections with certain Google APIs. When the Firebase CLI (via google-auth-library) attempts to talk to googleapis.com to exchange your Service Account key for an active token, Node abruptly closes the connection, triggering the Premature close error. Because authentication fails halfway through, the CLI falls back and assumes you aren't authenticated at all.

> This started happening suddenly because GitHub's hosted virtual runners recently updated their default Node.js environments to these affected versions.

todo: these lines from *.yml scripts of forced node version must be removed later on cuz newer Angular won't support that