### PR TITLE
J&D wiki improvements no.2 + design changes

### DIFF
--- a/libs/authentication/feature/src/lib/account-link-dialog.component.ts
+++ b/libs/authentication/feature/src/lib/account-link-dialog.component.ts
@@ -157,16 +157,8 @@ type DialogState = 'form' | 'migrating' | 'done' | 'error';
       position: relative;
 
       &::before {
-        content: '◆';
-        position: absolute;
-        top: -7px; left: 50%;
-        transform: translateX(-50%);
-        font-size: 9px;
-        color: rgba(200,160,60,.6);
-        background: rgba(8,5,18,1);
-        padding: 0 6px;
-        pointer-events: none;
-        z-index: 2;
+        content: '';
+        display: none;
       }
     }
 

--- a/libs/character-sheet/data-access/src/lib/character-sheet.store.ts
+++ b/libs/character-sheet/data-access/src/lib/character-sheet.store.ts
@@ -157,7 +157,7 @@ export const CharacterSheetStore = signalStore(
                 (_: any) => {
                   patchState(store, { characterSheetSaved: true, characterSheetError: '', loading: false });
                   _localStorage.setDataSync(DB_BACKUP_KEY_CHARACTER, req);
-                  _snackBar.open('⚔️ Karta postavy uložena do trezoru!', '✕', {
+                  _snackBar.open('Data uložena', '✕', {
                     verticalPosition: 'top',
                     duration: 2300,
                     panelClass: ['snackbar--save'],
@@ -188,7 +188,7 @@ export const CharacterSheetStore = signalStore(
                 (_: any) => {
                   patchState(store, { groupSheetSaved: true, characterSheetError: '', loading: false });
                   _localStorage.setDataSync(DB_BACKUP_KEY_GROUP, req);
-                  _snackBar.open('🛡️ Karta družiny uložena do trezoru!', '✕', {
+                  _snackBar.open('Data uložena', '✕', {
                     verticalPosition: 'top',
                     duration: 2300,
                     panelClass: ['snackbar--save'],
@@ -219,7 +219,7 @@ export const CharacterSheetStore = signalStore(
                 (_: any) => {
                   patchState(store, { characterSheetError: '', loading: false });
                   _localStorage.setDataSync(DB_BACKUP_KEY_NOTES, req);
-                  _snackBar.open('📜 Poznámky zapsány do svitku!', '✕', {
+                  _snackBar.open('Data uložena', '✕', {
                     verticalPosition: 'top',
                     duration: 2300,
                     panelClass: ['snackbar--save'],
@@ -267,7 +267,7 @@ export const CharacterSheetStore = signalStore(
               tapResponse(
                 () => {
                   patchState(store, { itemVault: req, loading: false });
-                  _snackBar.open('💰 Předměty uloženy do truhly!', '✕', {
+                  _snackBar.open('Data uložena', '✕', {
                     verticalPosition: 'top',
                     duration: 2300,
                     panelClass: ['snackbar--save'],
@@ -316,7 +316,7 @@ export const CharacterSheetStore = signalStore(
               tapResponse(
                 () => {
                   patchState(store, { quests: req, loading: false });
-                  _snackBar.open('📜 Questy zapsány do deníku!', '✕', {
+                  _snackBar.open('Data uložena', '✕', {
                     verticalPosition: 'top',
                     duration: 2300,
                     panelClass: ['snackbar--save'],

--- a/libs/character-sheet/feature/src/lib/character-sheet-second-page.component.ts
+++ b/libs/character-sheet/feature/src/lib/character-sheet-second-page.component.ts
@@ -111,7 +111,7 @@ import { CsSvgSheetComponent } from './character-sheet/cs-svg-sheet.component';
       class="field char-img-wrap"
       style="top:835px; left:64px; width:369px; height:403px;"
       (click)="triggerFileInput()"
-      matTooltip="Klikni pro nahrání nebo změnu obrázku (max 500 KB, GIF) - poslední záložka Konvertor Obrázků"
+      matTooltip="Klikni pro nahrání nebo změnu obrázku (max 500 KB, GIF) - Menu > Nástroje > poslední záložka Konvertor Obrázků"
     >
       @if (base64Image()) {
         <img [src]="base64Image()!" alt="Obrázek postavy" class="char-img" />

--- a/libs/character-sheet/feature/src/lib/character-sheet.component.scss
+++ b/libs/character-sheet/feature/src/lib/character-sheet.component.scss
@@ -72,6 +72,15 @@
     color: rgba(255, 255, 255, 0.92);
   }
 
+  select.field {
+    background: rgba(18, 14, 8, 0.96);
+    color: rgba(220, 210, 190, 0.9);
+    option {
+      background: #141008;
+      color: rgba(220, 210, 190, 0.9);
+    }
+  }
+
   // Weight highlights must override the dark .field background
   .field.soft-weight,
   .soft-weight {

--- a/libs/character-sheet/feature/src/lib/character-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/character-sheet.component.ts
@@ -2,6 +2,7 @@ import {
   afterNextRender,
   ChangeDetectionStrategy,
   Component,
+  computed,
   DestroyRef,
   effect,
   inject,
@@ -90,11 +91,13 @@ const CS_DEFAULT_SECTIONS: readonly SectionConfig[] = [
       <h2 class="cs-section-title cs-main-title">
         Karta Postavy
         <span class="cs-collapse-all-wrap">
-          <button type="button" class="cs-collapse-all-btn" (click)="expandAll()" matTooltip="Rozbalit vše">
-            <mat-icon>unfold_more</mat-icon>
-          </button>
-          <button type="button" class="cs-collapse-all-btn" (click)="collapseAll()" matTooltip="Sbalit vše">
-            <mat-icon>unfold_less</mat-icon>
+          <button
+            type="button"
+            class="cs-collapse-all-btn"
+            (click)="allExpanded() ? collapseAll() : expandAll()"
+            [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozbalit vše'"
+          >
+            <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
           </button>
         </span>
       </h2>
@@ -236,6 +239,7 @@ export class CharacterSheetComponent {
   _viewInitialized = signal(false);
 
   private readonly collapsibles = viewChildren(CsCollapsibleComponent);
+  readonly allExpanded = computed(() => this.collapsibles().every(c => c.isOpen()));
 
   fb = new FormBuilder().nonNullable;
   form = this.fb.group<CharacterSheetForm>({

--- a/libs/character-sheet/feature/src/lib/character-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/character-sheet.component.ts
@@ -188,7 +188,7 @@ const CS_DEFAULT_SECTIONS: readonly SectionConfig[] = [
   `,
   styleUrl: 'character-sheet.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: { '[class.theme-dark]': 'sheetTheme.darkMode()' },
+  host: { '[class.theme-dark]': 'sheetTheme.darkMode()', '(document:keydown.control.s)': 'ctrlSave($event)' },
   imports: [
     ReactiveFormsModule,
     CharacterSheetSecondPageComponent,
@@ -679,6 +679,8 @@ export class CharacterSheetComponent {
     moveItemInArray(sections, event.previousIndex, event.currentIndex);
     this.orderedSections.set(sections);
   }
+
+  ctrlSave(e: Event): void { e.preventDefault(); this.onSaveClick(); }
 
   onSaveClick() {
     const username = this.authService.currentUser()?.username;

--- a/libs/character-sheet/feature/src/lib/conditions/conditions-tracker.component.ts
+++ b/libs/character-sheet/feature/src/lib/conditions/conditions-tracker.component.ts
@@ -59,10 +59,12 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
   ],
   styles: `
     :host {
+      --hl-color: #c8a050;
+      --hl-glow: rgba(200, 160, 80, 0.45);
       display: block;
       height: 100%;
       overflow-y: auto;
-      padding: 24px 32px 40px;
+      padding: 8px 12px 16px;
       box-sizing: border-box;
       font-family: sans-serif;
     }
@@ -100,11 +102,9 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
     }
 
     .ct-card {
-      --cond-color: transparent;
-      --cond-glow: transparent;
       position: relative;
       display: flex; align-items: center; justify-content: center;
-      padding: 7px 8px;
+      padding: 10px 12px;
       background: linear-gradient(160deg, rgba(28,20,14,.96) 0%, rgba(18,12,8,.98) 100%);
       border: 1px solid rgba(255,255,255,.07);
       border-radius: 4px;
@@ -118,11 +118,11 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
       &:hover { background: rgba(255,255,255,.05); }
 
       &--active {
-        border-color: var(--cond-color) !important;
-        box-shadow: 0 0 10px var(--cond-glow), inset 0 0 16px rgba(0,0,0,.3);
+        border-color: var(--hl-color) !important;
+        box-shadow: 0 0 10px var(--hl-glow), inset 0 0 16px rgba(0,0,0,.3);
         background: linear-gradient(160deg, rgba(40,28,20,.97) 0%, rgba(24,16,10,.99) 100%) !important;
 
-        .ct-card__name { color: var(--cond-color); }
+        .ct-card__name { color: var(--hl-color); }
         .ct-card__active-dot { opacity: 1; }
       }
     }
@@ -136,8 +136,8 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
     .ct-card__active-dot {
       position: absolute; top: 4px; right: 5px;
       width: 5px; height: 5px; border-radius: 50%;
-      background: var(--cond-color);
-      box-shadow: 0 0 5px var(--cond-glow);
+      background: var(--hl-color);
+      box-shadow: 0 0 5px var(--hl-glow);
       opacity: 0;
       transition: opacity .2s;
     }
@@ -163,8 +163,8 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
       outline: none;
 
       &--active {
-        border-color: rgba(210,60,50,.7) !important;
-        box-shadow: 0 0 10px rgba(200,50,40,.4);
+        border-color: var(--hl-color) !important;
+        box-shadow: 0 0 10px var(--hl-glow);
       }
 
       &:hover { background: rgba(255,255,255,.04); }
@@ -172,15 +172,32 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
       &__level {
         font-size: 14px; font-weight: 700; color: rgba(255,255,255,.25);
         line-height: 1;
-        .ct-exhaustion-btn--active & { color: rgba(220,100,80,.9); }
+        .ct-exhaustion-btn--active & { color: var(--hl-color); }
       }
     }
 
+    .ct-exhaustion-effects-list {
+      margin-top: 8px;
+      display: flex; flex-direction: column; gap: 4px;
+    }
+
     .ct-exhaustion-effect {
-      margin-top: 6px; font-family: sans-serif; font-size: 11px;
+      font-family: sans-serif; font-size: 11px;
       color: rgba(255,255,255,.3); font-style: italic; line-height: 1.4;
-      min-height: 20px; transition: color .2s;
-      &--active { color: rgba(220,100,80,.7); }
+      min-height: 16px; transition: color .2s;
+      display: flex; align-items: baseline; gap: 6px;
+
+      &--active { color: rgba(200, 160, 80, 0.75); }
+
+      &__lvl {
+        font-style: normal; font-size: 10px; font-weight: 700;
+        color: var(--hl-color); opacity: .7; min-width: 14px; text-align: right;
+      }
+    }
+
+    .ct-exhaustion-none {
+      margin-top: 6px; font-family: sans-serif; font-size: 11px;
+      color: rgba(255,255,255,.25); font-style: italic;
     }
   `,
   template: `
@@ -201,8 +218,6 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
           type="button"
           class="ct-card"
           [class.ct-card--active]="isActive(cond.id)"
-          [style.--cond-color]="cond.color"
-          [style.--cond-glow]="cond.glow"
           (click)="toggle(cond.id)"
           [matTooltip]="cond.description"
           matTooltipShowDelay="400"
@@ -231,11 +246,16 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
         </button>
       }
     </div>
-    <div class="ct-exhaustion-effect" [class.ct-exhaustion-effect--active]="exhaustion() > 0">
-      @if (exhaustion() > 0) {
-        Efekt: {{ exhaustionEffects[exhaustion()] }}
+    <div class="ct-exhaustion-effects-list">
+      @if (exhaustion() === 0) {
+        <div class="ct-exhaustion-none">Žádné vyčerpání</div>
       } @else {
-        Žádné vyčerpání
+        @for (eff of activeExhaustionEffects(); track eff.level) {
+          <div class="ct-exhaustion-effect ct-exhaustion-effect--active">
+            <span class="ct-exhaustion-effect__lvl">{{ eff.level }}</span>
+            {{ eff.text }}
+          </div>
+        }
       }
     </div>
   `,
@@ -249,6 +269,12 @@ export class ConditionsTrackerComponent implements OnInit {
   exhaustion = signal<number>(0);
 
   activeCount = computed(() => this.active().size + (this.exhaustion() > 0 ? 1 : 0));
+  activeExhaustionEffects = computed(() =>
+    Array.from({ length: this.exhaustion() }, (_, i) => ({
+      level: i + 1,
+      text: EXHAUSTION_EFFECTS[i + 1],
+    }))
+  );
 
   ngOnInit(): void {
     this._load();

--- a/libs/character-sheet/feature/src/lib/conditions/conditions-tracker.component.ts
+++ b/libs/character-sheet/feature/src/lib/conditions/conditions-tracker.component.ts
@@ -64,25 +64,14 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
       overflow-y: auto;
       padding: 24px 32px 40px;
       box-sizing: border-box;
-      font-family: 'Mikadan', sans-serif;
+      font-family: sans-serif;
     }
 
-    /* ── Header ─────────────────────────────────── */
-    .ct-header {
-      display: flex; align-items: flex-start; justify-content: space-between;
-      flex-wrap: wrap; gap: 14px; margin-bottom: 24px; padding-bottom: 14px;
-      border-bottom: 2px solid transparent;
-      border-image: linear-gradient(90deg, transparent, rgba(200,160,60,.6) 20%, rgba(220,180,60,.8) 50%, rgba(200,160,60,.6) 80%, transparent) 1;
+    /* ── Top bar (clear btn + active badge) ─────── */
+    .ct-top-bar {
+      display: flex; align-items: center; justify-content: flex-end;
+      gap: 12px; margin-bottom: 16px;
     }
-    .ct-title {
-      font-size: 22px; letter-spacing: .12em; text-transform: uppercase;
-      color: #e8c96a; text-shadow: 0 0 18px rgba(200,160,60,.4), 0 0 4px rgba(200,160,60,.2);
-      display: flex; align-items: center; gap: 10px;
-      mat-icon { font-size: 26px; width: 26px; height: 26px; color: #c8a03c; }
-    }
-    .ct-subtitle { font-size: 11px; color: rgba(200,160,60,.4); letter-spacing: .05em; margin-top: 5px; font-family: sans-serif; font-style: italic; text-transform: none; }
-
-    .ct-header-right { display: flex; align-items: center; gap: 12px; }
 
     .ct-active-badge {
       display: inline-flex; align-items: center; gap: 6px;
@@ -95,20 +84,18 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
     }
 
     .ct-clear-btn {
-      font-family: 'Mikadan', sans-serif; font-size: 10px; letter-spacing: .1em; text-transform: uppercase;
+      font-family: sans-serif; font-size: 10px; letter-spacing: .1em; text-transform: uppercase;
       border: 1px solid rgba(255,255,255,.1); border-radius: 3px; background: transparent;
       color: rgba(255,255,255,.3); padding: 6px 14px; cursor: pointer;
-      display: flex; align-items: center; gap: 5px;
       transition: background .18s, border-color .18s, color .18s;
-      mat-icon { font-size: 14px; width: 14px; height: 14px; }
       &:hover { background: rgba(180,50,50,.12); border-color: rgba(200,80,60,.3); color: rgba(220,100,80,.85); }
     }
 
     /* ── Conditions grid ─────────────────────────── */
     .ct-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-      gap: 10px;
+      grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+      gap: 8px;
       margin-bottom: 28px;
     }
 
@@ -116,50 +103,41 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
       --cond-color: transparent;
       --cond-glow: transparent;
       position: relative;
-      display: flex; flex-direction: column; align-items: center; justify-content: center;
-      gap: 6px; padding: 12px 8px 10px;
+      display: flex; align-items: center; justify-content: center;
+      padding: 7px 8px;
       background: linear-gradient(160deg, rgba(28,20,14,.96) 0%, rgba(18,12,8,.98) 100%);
       border: 1px solid rgba(255,255,255,.07);
       border-radius: 4px;
       cursor: pointer;
-      transition: background .15s, border-color .15s, box-shadow .15s, transform .1s;
-      font-family: 'Mikadan', sans-serif;
+      transition: background .15s, border-color .15s, box-shadow .15s;
+      font-family: sans-serif;
       outline: none;
       user-select: none;
       text-align: center;
 
-      &:hover { background: rgba(255,255,255,.03); transform: translateY(-1px); }
-      &:active { transform: translateY(0); }
+      &:hover { background: rgba(255,255,255,.05); }
 
       &--active {
         border-color: var(--cond-color) !important;
-        box-shadow: 0 0 12px var(--cond-glow), inset 0 0 20px rgba(0,0,0,.3);
+        box-shadow: 0 0 10px var(--cond-glow), inset 0 0 16px rgba(0,0,0,.3);
         background: linear-gradient(160deg, rgba(40,28,20,.97) 0%, rgba(24,16,10,.99) 100%) !important;
-        transform: translateY(-2px);
 
-        .ct-card__icon { color: var(--cond-color); text-shadow: 0 0 10px var(--cond-glow); }
         .ct-card__name { color: var(--cond-color); }
         .ct-card__active-dot { opacity: 1; }
       }
     }
 
-    .ct-card__icon {
-      font-size: 22px !important; width: 22px !important; height: 22px !important;
-      color: rgba(255,255,255,.2);
-      transition: color .15s, text-shadow .15s;
-    }
-
     .ct-card__name {
-      font-size: 10px; letter-spacing: .1em; text-transform: uppercase;
-      color: rgba(255,255,255,.3); line-height: 1.2;
+      font-size: 12px; letter-spacing: .06em; text-transform: uppercase;
+      color: rgba(255,255,255,.35); line-height: 1.2;
       transition: color .15s;
     }
 
     .ct-card__active-dot {
-      position: absolute; top: 5px; right: 6px;
-      width: 6px; height: 6px; border-radius: 50%;
+      position: absolute; top: 4px; right: 5px;
+      width: 5px; height: 5px; border-radius: 50%;
       background: var(--cond-color);
-      box-shadow: 0 0 6px var(--cond-glow);
+      box-shadow: 0 0 5px var(--cond-glow);
       opacity: 0;
       transition: opacity .2s;
     }
@@ -169,7 +147,6 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
       font-size: 10px; letter-spacing: .14em; text-transform: uppercase;
       color: rgba(255,255,255,.22); margin-bottom: 10px;
       display: flex; align-items: center; gap: 6px;
-      mat-icon { font-size: 14px; width: 14px; height: 14px; }
     }
 
     .ct-exhaustion-track {
@@ -181,7 +158,7 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
       gap: 3px; width: 50px; padding: 8px 4px;
       background: linear-gradient(160deg, rgba(28,20,14,.96), rgba(18,12,8,.98));
       border: 1px solid rgba(255,255,255,.07); border-radius: 3px;
-      cursor: pointer; font-family: 'Mikadan', sans-serif;
+      cursor: pointer; font-family: sans-serif;
       transition: background .15s, border-color .15s, box-shadow .15s;
       outline: none;
 
@@ -190,7 +167,7 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
         box-shadow: 0 0 10px rgba(200,50,40,.4);
       }
 
-      &:hover { background: rgba(255,255,255,.03); }
+      &:hover { background: rgba(255,255,255,.04); }
 
       &__level {
         font-size: 14px; font-weight: 700; color: rgba(255,255,255,.25);
@@ -205,32 +182,16 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
       min-height: 20px; transition: color .2s;
       &--active { color: rgba(220,100,80,.7); }
     }
-
-    /* ── Hint row ────────────────────────────────── */
-    .ct-hint {
-      margin-top: 20px; font-family: sans-serif; font-size: 10px;
-      color: rgba(255,255,255,.12); letter-spacing: .03em; font-style: italic;
-    }
   `,
   template: `
-    <div class="ct-header">
-      <div>
-        <div class="ct-title">
-          <mat-icon>health_and_safety</mat-icon>
-          Stavy &amp; Podmínky
-        </div>
-        <div class="ct-subtitle">Klikni na stav pro aktivaci — uloženo automaticky v prohlížeči</div>
-      </div>
-      <div class="ct-header-right">
-        <span class="ct-active-badge" [class.ct-active-badge--hidden]="activeCount() === 0">
-          <mat-icon>warning</mat-icon>
-          {{ activeCount() }} aktivní{{ activeCount() === 1 ? '' : 'ch' }}
-        </span>
-        <button class="ct-clear-btn" type="button" (click)="clearAll()" matTooltip="Zrušit všechny aktivní stavy">
-          <mat-icon>clear_all</mat-icon>
-          Vymazat vše
-        </button>
-      </div>
+    <div class="ct-top-bar">
+      <span class="ct-active-badge" [class.ct-active-badge--hidden]="activeCount() === 0">
+        <mat-icon>warning</mat-icon>
+        {{ activeCount() }} aktivní{{ activeCount() === 1 ? '' : 'ch' }}
+      </span>
+      <button class="ct-clear-btn" type="button" (click)="clearAll()" matTooltip="Zrušit všechny aktivní stavy">
+        Vymazat vše
+      </button>
     </div>
 
     <!-- Conditions grid -->
@@ -244,9 +205,8 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
           [style.--cond-glow]="cond.glow"
           (click)="toggle(cond.id)"
           [matTooltip]="cond.description"
-          matTooltipShowDelay="300"
+          matTooltipShowDelay="400"
         >
-          <mat-icon class="ct-card__icon">{{ cond.icon }}</mat-icon>
           <span class="ct-card__name">{{ cond.name }}</span>
           <span class="ct-card__active-dot"></span>
         </button>
@@ -255,7 +215,6 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
 
     <!-- Exhaustion -->
     <div class="ct-section-label">
-      <mat-icon>battery_alert</mat-icon>
       Vyčerpání (úroveň {{ exhaustion() }}/6)
     </div>
     <div class="ct-exhaustion-track">
@@ -266,6 +225,7 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
           [class.ct-exhaustion-btn--active]="exhaustion() >= lvl"
           (click)="setExhaustion(exhaustion() === lvl ? lvl - 1 : lvl)"
           [matTooltip]="exhaustionEffects[lvl]"
+          matTooltipShowDelay="400"
         >
           <span class="ct-exhaustion-btn__level">{{ lvl }}</span>
         </button>
@@ -277,10 +237,6 @@ export const LS_KEY = PLAYER_CONDITIONS_KEY;
       } @else {
         Žádné vyčerpání
       }
-    </div>
-
-    <div class="ct-hint">
-      Klikni na podmínku pro aktivaci/deaktivaci. Hover zobrazí popis efektu. Stavy jsou ukládány v prohlížeči (localStorage).
     </div>
   `,
 })

--- a/libs/character-sheet/feature/src/lib/group-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/group-sheet.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, signal, untracked, viewChildren } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, inject, signal, untracked, viewChildren } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { GroupInventoryForm, GroupSheetForm } from '@dn-d-servant/character-sheet-util';
 import { RichTextareaComponent, SpinnerOverlayComponent } from '@dn-d-servant/ui';
@@ -47,11 +47,13 @@ const GS_DEFAULT_SECTIONS: readonly GsSectionConfig[] = [
       <h2 class="cs-section-title cs-main-title">
         Karta Družiny
         <span class="cs-collapse-all-wrap">
-          <button type="button" class="cs-collapse-all-btn" (click)="expandAll()" matTooltip="Rozbalit vše">
-            <mat-icon>unfold_more</mat-icon>
-          </button>
-          <button type="button" class="cs-collapse-all-btn" (click)="collapseAll()" matTooltip="Sbalit vše">
-            <mat-icon>unfold_less</mat-icon>
+          <button
+            type="button"
+            class="cs-collapse-all-btn"
+            (click)="allExpanded() ? collapseAll() : expandAll()"
+            [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozbalit vše'"
+          >
+            <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
           </button>
         </span>
       </h2>
@@ -579,6 +581,7 @@ export class GroupSheetComponent {
   );
 
   private readonly collapsibles = viewChildren(CsCollapsibleComponent);
+  readonly allExpanded = computed(() => this.collapsibles().every(c => c.isOpen()));
 
   private readonly documentName = '_group';
   animalsSelect = animalsSelect;

--- a/libs/character-sheet/feature/src/lib/group-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/group-sheet.component.ts
@@ -558,7 +558,7 @@ const GS_DEFAULT_SECTIONS: readonly GsSectionConfig[] = [
   `,
   styleUrl: 'character-sheet.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: { '[class.theme-dark]': 'sheetTheme.darkMode()' },
+  host: { '[class.theme-dark]': 'sheetTheme.darkMode()', '(document:keydown.control.s)': 'ctrlSave($event)' },
   imports: [ReactiveFormsModule, SpinnerOverlayComponent, MatIcon, MatTooltip, NgClass, RichTextareaComponent, CsCollapsibleComponent, CsFloatingActionsComponent, CdkDropList, CsSvgSheetComponent],
 })
 export class GroupSheetComponent {
@@ -757,6 +757,8 @@ export class GroupSheetComponent {
     moveItemInArray(sections, event.previousIndex, event.currentIndex);
     this.orderedSections.set(sections);
   }
+
+  ctrlSave(e: Event): void { e.preventDefault(); this.onSaveClick(); }
 
   onSaveClick() {
     const username = this.authService.currentUser()?.username;

--- a/libs/character-sheet/feature/src/lib/help-dialogs/autofill-abilities-dialog.component.ts
+++ b/libs/character-sheet/feature/src/lib/help-dialogs/autofill-abilities-dialog.component.ts
@@ -29,6 +29,8 @@ import { FormsModule } from '@angular/forms';
           <span>Příště nezobrazovat</span>
         </label>
       </div>
+      
+      <p style="color: red;">Nezapomeň pravidelně ukládat všechny svoje změny přes tlačítka Uložit nebo Ctrl+S</p>
 
       <div class="autofill-intro">
         <p class="autofill-intro__text">

--- a/libs/character-sheet/feature/src/lib/image-converter/image-converter.component.ts
+++ b/libs/character-sheet/feature/src/lib/image-converter/image-converter.component.ts
@@ -380,26 +380,14 @@ const SCALE_STEPS = [1.0, 0.78, 0.6, 0.45, 0.32, 0.22, 0.15];
     }
   `,
   template: `
-    <!-- ── Header ── -->
-    <div class="ic-header">
-      <div>
-        <div class="ic-title">
-          <mat-icon>auto_fix_high</mat-icon>
-          Konvertor Obrázků
-        </div>
-        <div class="ic-subtitle">
-          Převod PNG / JPG / JPEG → GIF · automatická redukce na max 200 KB pro nahrání jako portrét postavy
-        </div>
-      </div>
-      @if (originalPreview()) {
+    @if (originalPreview()) {
+      <div class="ic-header">
         <button class="ic-reset-btn" type="button" (click)="reset()">
           <mat-icon>restart_alt</mat-icon>
           Nový obrázek
         </button>
-      }
-    </div>
-
-    <!-- ── Drop zone (shown only before a file is picked) ── -->
+      </div>
+    }    <!-- ── Drop zone (shown only before a file is picked) ── -->
     @if (!originalPreview()) {
       <div
         class="ic-dropzone"

--- a/libs/character-sheet/feature/src/lib/import-data-dialog.component.ts
+++ b/libs/character-sheet/feature/src/lib/import-data-dialog.component.ts
@@ -377,8 +377,8 @@ interface SelectableItem {
 
     .id-warn-title {
       margin: 0 0 4px;
-      font-family: 'Mikadan', sans-serif;
-      font-size: 14px; color: #e8a060; letter-spacing: .04em;
+      font-family: sans-serif;
+      font-size: 12px; color: #e8a060; letter-spacing: .08em; text-transform: uppercase;
     }
 
     .id-warn-text {
@@ -491,56 +491,28 @@ interface SelectableItem {
     @keyframes id-spin { to { transform: rotate(360deg); } }
 
     .id-loading-text {
-      margin: 0; font-family: 'Mikadan', sans-serif;
-      font-size: 15px; color: #e8c96a; letter-spacing: .06em;
+      margin: 0; font-family: sans-serif;
+      font-size: 13px; color: #e8c96a; letter-spacing: .1em; text-transform: uppercase;
     }
     .id-loading-sub { margin: 0; font-size: 12px; color: rgba(160,140,110,.55); }
 
     /* ── Success ─────────────────────────────────────────────────── */
     .id-success-icon { font-size: 44px; filter: drop-shadow(0 0 10px rgba(60,200,80,.3)); }
     .id-done-title {
-      margin: 0; font-family: 'Mikadan', sans-serif;
-      font-size: 18px; color: #e8c96a; letter-spacing: .06em;
+      margin: 0; font-family: sans-serif;
+      font-size: 14px; color: #e8c96a; letter-spacing: .1em; text-transform: uppercase;
     }
-    .id-done-sub { margin: 0; font-size: 13px; color: rgba(200,185,155,.75); line-height: 1.5; }
+    .id-done-sub { margin: 0; font-size: 12px; color: rgba(200,185,155,.75); line-height: 1.5; }
 
-    /* ── Buttons ─────────────────────────────────────────────────── */
-    .id-btn {
-      display: flex; align-items: center; justify-content: center; gap: 6px;
-      padding: 9px 18px;
-      border-radius: 6px;
-      font-family: 'Mikadan', sans-serif; font-size: 14px; letter-spacing: .06em;
-      cursor: pointer; transition: background .18s, border-color .18s, transform .12s;
-      border: 1px solid;
-
-      mat-icon { font-size: 16px; width: 16px; height: 16px; }
+    /* ── Buttons — use pt-filter-btn global style ──────────────────── */
+    .id-btn { display: inline-flex; align-items: center; justify-content: center; gap: 5px;
+      padding: 4px 12px; border-radius: 6px; font-family: sans-serif; font-size: 11px;
+      letter-spacing: .1em; text-transform: uppercase; cursor: pointer;
+      background: rgba(200,160,60,.08); border: 1px solid rgba(200,160,60,.2); color: #9a8a6a;
+      transition: background .15s, border-color .15s, color .15s;
+      mat-icon { font-size: 14px; width: 14px; height: 14px; flex-shrink: 0; }
+      &:hover:not(:disabled) { background: rgba(200,160,60,.15); color: #d4c9a0; border-color: rgba(200,160,60,.4); }
       &:disabled { opacity: .4; cursor: not-allowed; }
-
-      &--cancel {
-        background: rgba(140,100,100,.12); border-color: rgba(140,100,100,.28); color: #b88888;
-        &:hover:not(:disabled) { background: rgba(140,100,100,.22); transform: translateY(-1px); }
-      }
-
-      &--primary {
-        background: linear-gradient(135deg, rgba(100,160,200,.2), rgba(80,140,180,.3));
-        border-color: rgba(100,160,200,.45); color: #7ab8e0;
-        &:hover:not(:disabled) {
-          background: linear-gradient(135deg, rgba(100,160,200,.32), rgba(80,140,180,.44));
-          border-color: rgba(100,160,200,.75); box-shadow: 0 0 16px rgba(100,160,200,.2);
-          transform: translateY(-1px);
-        }
-      }
-
-      &--danger {
-        background: linear-gradient(135deg, rgba(200,80,60,.18), rgba(180,60,40,.28));
-        border-color: rgba(200,80,60,.45); color: #e89080;
-        text-shadow: 0 0 8px rgba(200,80,60,.35);
-        &:hover:not(:disabled) {
-          background: linear-gradient(135deg, rgba(200,80,60,.3), rgba(180,60,40,.4));
-          border-color: rgba(200,80,60,.75); box-shadow: 0 0 16px rgba(200,80,60,.2);
-          transform: translateY(-1px);
-        }
-      }
     }
   `,
 })

--- a/libs/character-sheet/feature/src/lib/import-data-dialog.component.ts
+++ b/libs/character-sheet/feature/src/lib/import-data-dialog.component.ts
@@ -243,16 +243,8 @@ interface SelectableItem {
       position: relative;
 
       &::before {
-        content: '◆';
-        position: absolute;
-        top: -7px; left: 50%;
-        transform: translateX(-50%);
-        font-size: 9px;
-        color: rgba(200,160,60,.6);
-        background: rgba(8,5,18,1);
-        padding: 0 6px;
-        pointer-events: none;
-        z-index: 2;
+        content: '';
+        display: none;
       }
     }
 

--- a/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.html
+++ b/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.html
@@ -1,232 +1,206 @@
-<div class="it-wrapper">
-  <div class="it-layout">
+@if (initDialogOpen()) {
+  <div class="it-init-backdrop" (click)="initDialogOpen.set(false)">
+    <div class="it-init-dialog" (click)="$event.stopPropagation()">
+      <h3 class="it-init-dialog__title">Inicializovat encounter</h3>
+      <p class="it-init-dialog__desc">Jak nastavit životy příšer?</p>
+      <div class="it-init-dialog__hp-hint">
+        <span class="it-init-dialog__formula-eg">Příklad: Goblin má <strong>7 (2k6)</strong> — 7 je průměr, 2k6 jsou 2 kostky šestky.</span>
+      </div>
+      <div class="it-init-dialog__actions">
+        <button type="button" class="pt-filter-btn" (click)="runInit('average')">
+          <mat-icon>calculate</mat-icon> Průměr
+        </button>
+        <button type="button" class="pt-filter-btn" (click)="runInit('dice')">
+          <mat-icon>casino</mat-icon> Hodit kostky
+        </button>
+        <button type="button" class="pt-filter-btn" (click)="initDialogOpen.set(false)">
+          Zrušit
+        </button>
+      </div>
+    </div>
+  </div>
+}
 
-    <!-- ── Initiative table card ────────────────────────────── -->
-    <div class="it-card">
+<div class="it-layout">
 
-      <!-- Init dialog overlay -->
-      @if (initDialogOpen()) {
-        <div class="it-init-overlay">
-          <div class="it-init-dialog">
-            <h3 class="it-init-dialog__title">Inicializovat encounter</h3>
-            <p class="it-init-dialog__desc">
-              Jak nastavit životy příšer?
-            </p>
-            <div class="it-init-dialog__hp-hint">
-              <span class="it-init-dialog__formula-eg">Příklad: Goblin má <strong>7 (2k6)</strong> — 7 je průměr, 2k6 jsou 2 kostky šestky.</span>
-            </div>
-            <div class="it-init-dialog__actions">
-              <button type="button" class="it-btn it-btn--avg" (click)="runInit('average')">
-                <mat-icon>calculate</mat-icon> Průměr
-              </button>
-              <button type="button" class="it-btn it-btn--dice" (click)="runInit('dice')">
-                <mat-icon>casino</mat-icon> Hodit kostky
-              </button>
-              <button type="button" class="it-btn it-btn--cancel" (click)="initDialogOpen.set(false)">
-                Zrušit
-              </button>
-            </div>
-          </div>
-        </div>
+  <!-- ── Initiative table ────────────────────────────────── -->
+  <div class="it-card">
+
+    <div class="it-col-headers">
+      <span class="it-col-header it-col-header--indicator"></span>
+      <span class="it-col-header it-col-header--sm">⚔ Init.</span>
+      <span class="it-col-header it-col-header--name">👤 Jméno</span>
+      <span class="it-col-header it-col-header--sm">🛡 OČ</span>
+      <span class="it-col-header it-col-header--hp">❤ HP</span>
+      <span class="it-col-header it-col-header--hp-adj">± HP</span>
+      <span class="it-col-header it-col-header--icon"></span>
+      @if (!disableMonsterSearch()) {
+        <span class="it-col-header it-col-header--icon"></span>
       }
+      <span class="it-col-header it-col-header--icon"></span>
+    </div>
 
-      <div class="it-header">
-        <mat-icon class="it-header__icon">shield</mat-icon>
-        <h2 class="it-header__title">Sledování iniciativy</h2>
-      </div>
-      <p class="it-notice">Data se ukládají pouze v tomto prohlížeči — na jiném zařízení budou řádky prázdné.</p>
-      <p class="it-notice it-notice--monsters">
-        Automatické doplňování jmen vychází z <strong>JaD wiki</strong> (Bestiář v češtině) i ze seznamu příšer
-        <strong>D&amp;D 2014 Monster Manual</strong> (v angličtině).
-        Celý anglický seznam najdeš na
-        <a href="https://www.aidedd.org/dnd-filters/monsters.php" target="_blank" rel="noopener">aidedd.org</a>.
-      </p>
+    <div class="it-rows">
+      @for (row of rows(); track row.id) {
+        <div
+          class="it-row"
+          [class.it-row--odd]="$index % 2 === 1"
+          [class.it-row--active]="$index === activeIndex()"
+          [class.it-row--card-open]="openCardByRowId().has(row.id)"
+        >
+          <span class="it-turn-indicator">{{ $index === activeIndex() ? '▶' : '' }}</span>
+          <input [(ngModel)]="row.initiative" type="number" class="it-input it-input--sm" placeholder="—" />
+          <autofill-input
+            [(ngModel)]="row.name"
+            [suggestions]="monsterNames"
+            placeholder="Název / jméno"
+            inputClass="it-input it-input--name"
+          />
+          <input [(ngModel)]="row.ac" type="number" class="it-input it-input--sm" placeholder="—" />
 
-      <div class="it-col-headers">
-        <span class="it-col-header it-col-header--indicator"></span>
-        <span class="it-col-header it-col-header--sm">⚔ Init.</span>
-        <span class="it-col-header it-col-header--name">👤 Jméno</span>
-        <span class="it-col-header it-col-header--sm">🛡 OČ</span>
-        <span class="it-col-header it-col-header--hp">❤ HP</span>
-        <span class="it-col-header it-col-header--hp-adj">± HP</span>
-        <span class="it-col-header it-col-header--icon"></span>
-        @if (!disableMonsterSearch()) {
-          <span class="it-col-header it-col-header--icon"></span>
-        }
-        <span class="it-col-header it-col-header--icon"></span>
-      </div>
+          <!-- HP input + bar -->
+          <div class="it-hp-col">
+            <input [(ngModel)]="row.hp" type="number" class="it-input it-input--sm" placeholder="—" />
+            @if (row.maxHp !== null && row.maxHp > 0) {
+              <div class="it-hp-bar">
+                <div
+                  class="it-hp-bar__fill"
+                  [style.width.%]="hpPercent(row)"
+                  [class.it-hp-bar__fill--high]="hpPercent(row) > 66"
+                  [class.it-hp-bar__fill--med]="hpPercent(row) <= 66 && hpPercent(row) > 33"
+                  [class.it-hp-bar__fill--low]="hpPercent(row) <= 33"
+                ></div>
+              </div>
+            }
+          </div>
 
-      <div class="it-rows">
-        @for (row of rows(); track row.id) {
-          <div
-            class="it-row"
-            [class.it-row--odd]="$index % 2 === 1"
-            [class.it-row--active]="$index === activeIndex()"
-            [class.it-row--card-open]="openCardByRowId().has(row.id)"
-          >
-            <span class="it-turn-indicator">{{ $index === activeIndex() ? '▶' : '' }}</span>
-            <input [(ngModel)]="row.initiative" type="number" class="it-input it-input--sm" placeholder="—" />
-            <autofill-input
-              [(ngModel)]="row.name"
-              [suggestions]="monsterNames"
-              placeholder="Název / jméno"
-              inputClass="it-input it-input--name"
-            />
-            <input [(ngModel)]="row.ac" type="number" class="it-input it-input--sm" placeholder="—" />
+          <!-- ± HP adjuster -->
+          <div class="it-hp-adj">
+            <button mat-icon-button type="button" class="it-hp-adj__btn it-hp-adj__btn--remove"
+              matTooltip="Odečíst HP" (click)="removeHp($index)">
+              <mat-icon>remove</mat-icon>
+            </button>
+            <input [(ngModel)]="row.hpDelta" type="number" min="1" class="it-hp-adj__input" />
+            <button mat-icon-button type="button" class="it-hp-adj__btn it-hp-adj__btn--add"
+              matTooltip="Přidat HP" (click)="addHp($index)">
+              <mat-icon>add</mat-icon>
+            </button>
+          </div>
 
-            <!-- HP input + bar -->
-            <div class="it-hp-col">
-              <input [(ngModel)]="row.hp" type="number" class="it-input it-input--sm" placeholder="—" />
-              @if (row.maxHp !== null && row.maxHp > 0) {
-                <div class="it-hp-bar">
-                  <div
-                    class="it-hp-bar__fill"
-                    [style.width.%]="hpPercent(row)"
-                    [class.it-hp-bar__fill--high]="hpPercent(row) > 66"
-                    [class.it-hp-bar__fill--med]="hpPercent(row) <= 66 && hpPercent(row) > 33"
-                    [class.it-hp-bar__fill--low]="hpPercent(row) <= 33"
-                  ></div>
-                </div>
-              }
-            </div>
-
-            <!-- ± HP adjuster -->
-            <div class="it-hp-adj">
-              <button mat-icon-button type="button" class="it-hp-adj__btn it-hp-adj__btn--remove"
-                matTooltip="Odečíst HP" (click)="removeHp($index)">
-                <mat-icon>remove</mat-icon>
-              </button>
-              <input [(ngModel)]="row.hpDelta" type="number" min="1" class="it-hp-adj__input" />
-              <button mat-icon-button type="button" class="it-hp-adj__btn it-hp-adj__btn--add"
-                matTooltip="Přidat HP" (click)="addHp($index)">
-                <mat-icon>add</mat-icon>
-              </button>
-            </div>
-
+          <button mat-icon-button type="button" class="it-copy-btn"
+            matTooltip="Kopírovat řádek (přidá B, C, D… za jméno)"
+            (click)="copyRow($index)">
+            <mat-icon>content_copy</mat-icon>
+          </button>
+          @if (!disableMonsterSearch()) {
             <button
               mat-icon-button
               type="button"
-              class="it-copy-btn"
-              matTooltip="Kopírovat řádek (přidá B, C, D… za jméno)"
-              (click)="copyRow($index)"
+              class="it-lookup-btn"
+              [class.it-lookup-btn--active]="openCardByRowId().has(row.id)"
+              [class.it-lookup-btn--loading]="openCardByRowId().get(row.id)?.loading"
+              [matTooltip]="openCardByRowId().has(row.id) ? 'Karta je již otevřena (zvýraznit)' : 'Vyhledat příšeru'"
+              (click)="lookupMonster(row.name, row.id)"
             >
-              <mat-icon>content_copy</mat-icon>
+              <mat-icon>{{ openCardByRowId().get(row.id)?.loading ? 'hourglass_empty' : 'search' }}</mat-icon>
             </button>
-            @if (!disableMonsterSearch()) {
-              <button
-                mat-icon-button
-                type="button"
-                class="it-lookup-btn"
-                [class.it-lookup-btn--active]="openCardByRowId().has(row.id)"
-                [class.it-lookup-btn--loading]="openCardByRowId().get(row.id)?.loading"
-                [matTooltip]="openCardByRowId().has(row.id) ? 'Karta je již otevřena (zvýraznit)' : 'Vyhledat příšeru'"
-                (click)="lookupMonster(row.name, row.id)"
-              >
-                <mat-icon>{{ openCardByRowId().get(row.id)?.loading ? 'hourglass_empty' : 'search' }}</mat-icon>
-              </button>
-            }
-            <button mat-icon-button type="button" class="it-remove-btn" title="Odstranit řádek" (click)="removeRow($index)">
-              <mat-icon>close</mat-icon>
-            </button>
-          </div>
-        }
-      </div>
-
-      <div class="it-actions">
-        <button type="button" class="it-btn it-btn--add" (click)="addRow()">
-          <mat-icon>add</mat-icon> Přidat
-        </button>
-        <button type="button" class="it-btn it-btn--next" (click)="nextRow()">
-          <mat-icon>arrow_downward</mat-icon> Další tah
-        </button>
-        <button type="button" class="it-btn it-btn--sort" (click)="sortRows()">
-          <mat-icon>sort</mat-icon> Seřadit
-        </button>
-        @if (!disableMonsterSearch()) {
-          <button type="button" class="it-btn it-btn--init" [disabled]="initRunning() || undefined" (click)="startInitDialog()">
-            <mat-icon>{{ initRunning() ? 'hourglass_empty' : 'play_arrow' }}</mat-icon>
-            Inicializovat
+          }
+          <button mat-icon-button type="button" class="it-remove-btn" title="Odstranit řádek" (click)="removeRow($index)">
+            <mat-icon>close</mat-icon>
           </button>
-        }
-        <button type="button" class="it-btn it-btn--save" (click)="save()">
-          <mat-icon>save</mat-icon> Uložit
-        </button>
-      </div>
-
-      @if (savedMessage()) {
-        <p class="it-saved-msg">✓ Uloženo do prohlížeče</p>
+        </div>
       }
     </div>
 
-    <!-- ── Monster cards queue ───────────────────────────────── -->
-    @if (openCards().length > 0) {
-      <div class="it-cards-area">
+    <div class="it-actions">
+      <button type="button" class="pt-filter-btn" (click)="addRow()">
+        <mat-icon>add</mat-icon> Přidat
+      </button>
+      <button type="button" class="pt-filter-btn" (click)="nextRow()">
+        <mat-icon>arrow_downward</mat-icon> Další tah
+      </button>
+      <button type="button" class="pt-filter-btn" (click)="sortRows()">
+        <mat-icon>sort</mat-icon> Seřadit
+      </button>
+      @if (!disableMonsterSearch()) {
+        <button type="button" class="pt-filter-btn" [disabled]="initRunning() || undefined" (click)="startInitDialog()">
+          <mat-icon>{{ initRunning() ? 'hourglass_empty' : 'play_arrow' }}</mat-icon>
+          Inicializovat
+        </button>
+      }
+      <button type="button" class="pt-filter-btn" (click)="save()">
+        <mat-icon>save</mat-icon> Uložit
+      </button>
+    </div>
 
-        <!-- Cards bar: title + expand/collapse all + close all -->
-        <div class="it-cards-bar">
-          <div class="it-cards-bar__title">
-            <mat-icon class="it-cards-bar__icon">bug_report</mat-icon>
-            <span>Příšery <span class="it-cards-bar__count">({{ openCards().length }})</span></span>
-          </div>
-          <div class="it-cards-bar__actions">
-            <button type="button" class="it-btn it-btn--expand-all" (click)="toggleAllCards()">
-              <mat-icon>{{ allCardsExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
-              {{ allCardsExpanded() ? 'Sbalit vše' : 'Rozvinout vše' }}
-            </button>
-            <button type="button" class="it-btn it-btn--close-all" (click)="closeAllCards()" matTooltip="Zavřít všechny karty příšer">
-              <mat-icon>clear_all</mat-icon>
-              Zavřít vše
-            </button>
-          </div>
+    @if (savedMessage()) {
+      <p class="it-saved-msg">✓ Uloženo do prohlížeče</p>
+    }
+  </div>
+
+  <!-- ── Monster cards queue ─────────────────────────────── -->
+  @if (openCards().length > 0) {
+    <div class="it-cards-area">
+
+      <div class="it-cards-bar">
+        <div class="it-cards-bar__title">
+          <mat-icon class="it-cards-bar__icon">bug_report</mat-icon>
+          <span>Příšery <span class="it-cards-bar__count">({{ openCards().length }})</span></span>
         </div>
+        <div class="it-cards-bar__actions">
+          <button type="button" class="pt-filter-btn" (click)="toggleAllCards()">
+            <mat-icon>{{ allCardsExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+            {{ allCardsExpanded() ? 'Sbalit vše' : 'Rozvinout vše' }}
+          </button>
+          <button type="button" class="pt-filter-btn" (click)="closeAllCards()" matTooltip="Zavřít všechny karty příšer">
+            <mat-icon>clear_all</mat-icon>
+            Zavřít vše
+          </button>
+        </div>
+      </div>
 
-        <!-- Card slots -->
-        <div class="it-cards-row">
-          @for (card of openCards(); track card.baseName) {
-            <div
-              class="it-card-slot"
-              [class.it-card-slot--highlight]="card.highlightAnim"
-              [class.it-card-slot--collapsed]="card.collapsed"
-              (animationend)="clearHighlight(card.baseName)"
-            >
-              <!-- Clickable header: row label + chevron -->
-              <div class="it-card-slot__header" (click)="toggleCardCollapse(card.baseName)">
-                <div class="it-card-slot__label">
-                  <mat-icon class="it-card-slot__label-icon">person_pin</mat-icon>
-                  <span>{{ card.rowName }}</span>
-                </div>
-                <mat-icon class="it-card-slot__chevron">
-                  {{ card.collapsed ? 'expand_more' : 'expand_less' }}
-                </mat-icon>
+      <div class="it-cards-row">
+        @for (card of openCards(); track card.baseName) {
+          <div
+            class="it-card-slot"
+            [class.it-card-slot--highlight]="card.highlightAnim"
+            [class.it-card-slot--collapsed]="card.collapsed"
+            (animationend)="clearHighlight(card.baseName)"
+          >
+            <div class="it-card-slot__header" (click)="toggleCardCollapse(card.baseName)">
+              <div class="it-card-slot__label">
+                <mat-icon class="it-card-slot__label-icon">person_pin</mat-icon>
+                <span>{{ card.rowName }}</span>
               </div>
+              <mat-icon class="it-card-slot__chevron">
+                {{ card.collapsed ? 'expand_more' : 'expand_less' }}
+              </mat-icon>
+            </div>
 
-              <!-- Animated body wrapper -->
-              <div class="it-card-body-wrapper">
-                <div class="it-card-body">
-                  @if (card.isJad) {
-                    <jad-monster-card
-                      [html]="card.jadMonsterHtml"
-                      [loading]="card.loading"
-                      [error]="card.error"
-                      (close)="closeCard(card.baseName)"
-                    />
-                  } @else {
-                    <monster-card
-                      [monster]="card.monster"
-                      [loading]="card.loading"
-                      [error]="card.error"
-                      (close)="closeCard(card.baseName)"
-                    />
-                  }
-                </div>
+            <div class="it-card-body-wrapper">
+              <div class="it-card-body">
+                @if (card.isJad) {
+                  <jad-monster-card
+                    [html]="card.jadMonsterHtml"
+                    [loading]="card.loading"
+                    [error]="card.error"
+                    (close)="closeCard(card.baseName)"
+                  />
+                } @else {
+                  <monster-card
+                    [monster]="card.monster"
+                    [loading]="card.loading"
+                    [error]="card.error"
+                    (close)="closeCard(card.baseName)"
+                  />
+                }
               </div>
             </div>
-          }
-        </div>
-
+          </div>
+        }
       </div>
-    }
 
-  </div>
+    </div>
+  }
+
 </div>
-

--- a/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.html
+++ b/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.html
@@ -113,6 +113,7 @@
     </div>
 
     <div class="it-actions">
+      <span class="it-actions__spacer"></span>
       <button type="button" class="pt-filter-btn" (click)="addRow()">
         <mat-icon>add</mat-icon> Přidat
       </button>
@@ -143,20 +144,14 @@
     <div class="it-cards-area">
 
       <div class="it-cards-bar">
-        <div class="it-cards-bar__title">
-          <mat-icon class="it-cards-bar__icon">bug_report</mat-icon>
-          <span>Příšery <span class="it-cards-bar__count">({{ openCards().length }})</span></span>
-        </div>
-        <div class="it-cards-bar__actions">
-          <button type="button" class="pt-filter-btn" (click)="toggleAllCards()">
-            <mat-icon>{{ allCardsExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
-            {{ allCardsExpanded() ? 'Sbalit vše' : 'Rozvinout vše' }}
-          </button>
-          <button type="button" class="pt-filter-btn" (click)="closeAllCards()" matTooltip="Zavřít všechny karty příšer">
-            <mat-icon>clear_all</mat-icon>
-            Zavřít vše
-          </button>
-        </div>
+        <button type="button" class="pt-filter-btn" (click)="toggleAllCards()">
+          <mat-icon>{{ allCardsExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+          {{ allCardsExpanded() ? 'Sbalit vše' : 'Rozvinout vše' }}
+        </button>
+        <button type="button" class="pt-filter-btn" (click)="closeAllCards()" matTooltip="Zavřít všechny karty příšer">
+          <mat-icon>clear_all</mat-icon>
+          Zavřít vše
+        </button>
       </div>
 
       <div class="it-cards-row">
@@ -175,6 +170,8 @@
               <mat-icon class="it-card-slot__chevron">
                 {{ card.collapsed ? 'expand_more' : 'expand_less' }}
               </mat-icon>
+              <button class="it-card-slot__close" type="button" title="Zavřít"
+                (click)="closeCard(card.baseName); $event.stopPropagation()">✕</button>
             </div>
 
             <div class="it-card-body-wrapper">

--- a/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.html
+++ b/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.html
@@ -164,14 +164,12 @@
           >
             <div class="it-card-slot__header" (click)="toggleCardCollapse(card.baseName)">
               <div class="it-card-slot__label">
-                <mat-icon class="it-card-slot__label-icon">person_pin</mat-icon>
                 <span>{{ card.rowName }}</span>
               </div>
-              <mat-icon class="it-card-slot__chevron">
-                {{ card.collapsed ? 'expand_more' : 'expand_less' }}
-              </mat-icon>
-              <button class="it-card-slot__close" type="button" title="Zavřít"
-                (click)="closeCard(card.baseName); $event.stopPropagation()">✕</button>
+              <button mat-icon-button class="it-card-slot__close" type="button" title="Zavřít"
+                (click)="closeCard(card.baseName); $event.stopPropagation()">
+                <mat-icon>close</mat-icon>
+              </button>
             </div>
 
             <div class="it-card-body-wrapper">

--- a/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.scss
+++ b/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.scss
@@ -314,6 +314,8 @@ datalist { display: none; }
   flex-wrap: wrap;
   padding-top: 14px;
   border-top: 1px solid rgba(255,255,255,.04);
+
+  &__spacer { flex: 1; }
 }
 
 // pt-filter-btn icon support (scoped to this component)
@@ -407,41 +409,12 @@ datalist { display: none; }
   gap: 12px;
 }
 
-// ── Cards bar (title + expand/collapse all) ───────────────────────────────────
+// ── Cards bar (buttons right-aligned) ────────────────────────────────────────
 .it-cards-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 0 2px;
-
-  &__title {
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    font-family: sans-serif;
-    font-size: 12px;
-    letter-spacing: .04em;
-    color: rgba(255,255,255,.38);
-  }
-
-  &__icon {
-    font-size: 15px !important;
-    width: 15px !important;
-    height: 15px !important;
-    color: rgba(160,30,30,.6);
-  }
-
-  &__count {
-    color: rgba(255,255,255,.2);
-    font-size: 10px;
-  }
-
-  &__actions {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-  }
+  justify-content: flex-end;
+  gap: 6px;
 }
 
 // ── Card row (wraps slots) ────────────────────────────────────────────────────
@@ -499,6 +472,29 @@ datalist { display: none; }
   }
 }
 
+.it-card-slot__close {
+  flex-shrink: 0;
+  width: 20px; height: 20px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  cursor: pointer;
+  color: rgba(255,255,255,.25);
+  font-size: 11px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background .15s, color .15s, border-color .15s;
+  margin-left: 2px;
+
+  &:hover {
+    background: rgba(160,30,30,.2);
+    border-color: rgba(200,50,40,.4);
+    color: #f08070;
+  }
+}
+
 .it-card-slot__label {
   display: flex;
   align-items: center;
@@ -542,6 +538,10 @@ datalist { display: none; }
   > .it-card-body {
     overflow: hidden;
     min-height: 0;
+    background: rgba(255,255,255,.02);
+    border: 1px solid rgba(255,255,255,.06);
+    border-top: none;
+    border-radius: 0 0 2px 2px;
 
     ::ng-deep .m-card,
     ::ng-deep .jmc-card {
@@ -549,6 +549,15 @@ datalist { display: none; }
       width: 100%;
       box-sizing: border-box;
       flex: none;
+      // Remove red left border
+      border-left: 1px solid rgba(255,255,255,.06) !important;
+      box-shadow: none !important;
+    }
+
+    // Hide built-in close buttons — close is in the header now
+    ::ng-deep .m-close,
+    ::ng-deep .jmc-close {
+      display: none !important;
     }
   }
 

--- a/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.scss
+++ b/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.scss
@@ -8,7 +8,7 @@
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 24px 28px;
+  padding: 24px 0;
   box-sizing: border-box;
   font-family: sans-serif;
 }

--- a/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.scss
+++ b/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.scss
@@ -1,11 +1,6 @@
 :host {
   display: block;
   height: 100%;
-  overflow: hidden;
-}
-
-.it-wrapper {
-  height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 24px 0;
@@ -20,83 +15,11 @@
   min-width: 0;
 }
 
-// ── Card ─────────────────────────────────────────────────────────────────────
+// ── Card (no bg, full width) ──────────────────────────────────────────────────
 .it-card {
   width: 100%;
-  max-width: 1100px;
   min-width: 0;
-  position: relative;
-  background: #0e0e12;
-  border: 1px solid rgba(255,255,255,.06);
-  border-left: 3px solid rgba(160,30,30,.7);
-  border-radius: 2px;
-  padding: 22px 26px 20px;
   box-sizing: border-box;
-  overflow-x: auto;
-  box-shadow:
-    0 2px 0 rgba(160,30,30,.4),
-    0 12px 40px rgba(0,0,0,.8),
-    inset 1px 0 0 rgba(255,255,255,.02);
-}
-
-// ── Header ────────────────────────────────────────────────────────────────────
-.it-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 4px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid rgba(255,255,255,.06);
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: -1px; left: 0;
-    width: 60px; height: 1px;
-    background: rgba(160,30,30,.8);
-  }
-}
-
-.it-header__icon {
-  font-size: 22px;
-  width: 22px;
-  height: 22px;
-  color: rgba(160,30,30,.8);
-}
-
-.it-header__title {
-  margin: 0;
-  font-family: sans-serif;
-  font-size: 20px;
-  font-weight: normal;
-  letter-spacing: .14em;
-  text-transform: uppercase;
-  color: #d0ccc4;
-}
-
-// ── Notices ───────────────────────────────────────────────────────────────────
-.it-notice {
-  margin: 10px 0 0;
-  font-size: 10px;
-  color: rgba(255,255,255,.2);
-  letter-spacing: .03em;
-  font-style: italic;
-
-  &--monsters {
-    margin-top: 3px;
-    color: rgba(255,255,255,.14);
-
-    strong { color: rgba(255,255,255,.28); font-weight: 600; font-style: normal; }
-
-    a {
-      color: rgba(180,100,90,.7);
-      text-decoration: none;
-      border-bottom: 1px dotted rgba(160,30,30,.4);
-      transition: color .15s, border-color .15s;
-      &:hover { color: #e08070; border-bottom-color: rgba(160,30,30,.7); }
-    }
-  }
 }
 
 // ── Column headers ────────────────────────────────────────────────────────────
@@ -223,7 +146,6 @@ datalist { display: none; }
 // ── Icon buttons ──────────────────────────────────────────────────────────────
 @keyframes it-spin { to { transform: rotate(360deg); } }
 
-// ── Shared touch-target clamp for all icon buttons in the tracker ─────────────
 .it-lookup-btn, .it-remove-btn, .it-copy-btn,
 .it-hp-adj__btn {
   overflow: hidden !important;
@@ -390,71 +312,20 @@ datalist { display: none; }
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+  padding-top: 14px;
+  border-top: 1px solid rgba(255,255,255,.04);
 }
 
-.it-btn {
-  font-family: sans-serif;
-  font-size: 10px;
-  letter-spacing: .12em;
-  text-transform: uppercase;
-  border-radius: 1px;
-  padding: 6px 14px;
-  cursor: pointer;
+// pt-filter-btn icon support (scoped to this component)
+.pt-filter-btn {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  transition: background .15s, color .15s, border-color .15s;
 
-  mat-icon { font-size: 14px; width: 14px; height: 14px; }
-
-  &--add  {
-    background: transparent;
-    border: 1px solid rgba(255,255,255,.1);
-    color: rgba(255,255,255,.4);
-    &:hover { background: rgba(255,255,255,.05); border-color: rgba(255,255,255,.2); color: #d0ccc4; }
-  }
-  &--next {
-    background: rgba(160,30,30,.12);
-    border: 1px solid rgba(160,30,30,.35);
-    color: rgba(200,80,70,.8);
-    &:hover { background: rgba(160,30,30,.22); border-color: rgba(200,80,70,.5); color: #e08070; }
-  }
-  &--sort {
-    background: transparent;
-    border: 1px solid rgba(255,255,255,.08);
-    color: rgba(255,255,255,.3);
-    &:hover { background: rgba(255,255,255,.04); border-color: rgba(255,255,255,.16); color: #c0bcb4; }
-  }
-  &--save {
-    background: transparent;
-    border: 1px solid rgba(255,255,255,.08);
-    color: rgba(255,255,255,.3);
-    &:hover { background: rgba(255,255,255,.04); border-color: rgba(255,255,255,.16); color: #c0bcb4; }
-  }
-  &--init {
-    background: rgba(200,160,60,.08);
-    border: 1px solid rgba(200,160,60,.3);
-    color: rgba(200,160,60,.8);
-    &:hover:not([disabled]) { background: rgba(200,160,60,.16); border-color: rgba(200,160,60,.55); color: #c8a03c; }
-    &[disabled] { opacity: 0.45; cursor: not-allowed; }
-  }
-  &--avg {
-    background: rgba(70,120,200,.1);
-    border: 1px solid rgba(70,120,200,.35);
-    color: rgba(120,170,240,.9);
-    &:hover { background: rgba(70,120,200,.2); border-color: rgba(70,120,200,.6); color: #88b8ff; }
-  }
-  &--dice {
-    background: rgba(200,160,60,.08);
-    border: 1px solid rgba(200,160,60,.35);
-    color: rgba(200,160,60,.9);
-    &:hover { background: rgba(200,160,60,.18); border-color: rgba(200,160,60,.6); color: #d4a840; }
-  }
-  &--cancel {
-    background: transparent;
-    border: 1px solid rgba(255,255,255,.08);
-    color: rgba(255,255,255,.3);
-    &:hover { background: rgba(255,255,255,.05); border-color: rgba(255,255,255,.16); color: #aaa; }
+  mat-icon, .mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
   }
 }
 
@@ -466,53 +337,55 @@ datalist { display: none; }
   color: rgba(100,180,110,.6);
 }
 
-// ── Init dialog overlay ───────────────────────────────────────────────────────
-.it-init-overlay {
-  position: absolute;
+// ── Init dialog (fixed modal) ─────────────────────────────────────────────────
+.it-init-backdrop {
+  position: fixed;
   inset: 0;
-  background: rgba(0,0,0,.7);
-  backdrop-filter: blur(3px);
+  z-index: 10000;
+  background: rgba(0,0,0,.75);
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 20;
-  border-radius: 2px;
+  animation: fadeIn .14s ease;
 }
 
 .it-init-dialog {
-  background: #0d0d11;
-  border: 1px solid rgba(200,160,60,.3);
-  border-left: 3px solid rgba(200,160,60,.7);
-  border-radius: 2px;
-  padding: 22px 26px 18px;
-  min-width: 300px;
-  box-shadow: 0 16px 48px rgba(0,0,0,.95);
+  background: linear-gradient(160deg, rgba(14,10,4,.99) 0%, rgba(8,6,2,1) 100%);
+  border: 1px solid rgba(200,160,60,.35);
+  border-top: 2px solid rgba(200,160,60,.7);
+  box-shadow: 0 12px 50px rgba(0,0,0,.9);
+  border-radius: 3px;
+  padding: 26px 30px 22px;
+  min-width: 320px;
+  max-width: 420px;
+  animation: scaleIn .14s ease;
 
   &__title {
-    margin: 0 0 6px;
     font-family: sans-serif;
-    font-size: 15px;
-    font-weight: normal;
-    letter-spacing: .13em;
+    font-size: 13px;
+    letter-spacing: .1em;
     text-transform: uppercase;
-    color: #d8c88a;
+    color: #e8c96a;
+    margin: 0 0 10px;
   }
 
   &__desc {
-    margin: 0 0 8px;
     font-size: 12px;
     color: rgba(255,255,255,.45);
     letter-spacing: .03em;
+    margin: 0 0 8px;
+    font-family: sans-serif;
   }
 
   &__hp-hint {
-    margin-bottom: 16px;
+    margin-bottom: 20px;
   }
 
   &__formula-eg {
     font-size: 11px;
     color: rgba(255,255,255,.28);
     font-style: italic;
+    font-family: sans-serif;
 
     strong {
       color: rgba(200,160,60,.8);
@@ -527,12 +400,11 @@ datalist { display: none; }
   }
 }
 
-// ── Monster cards area ────────────────────────────────────────────────────────
+// ── Monster cards area (full width) ──────────────────────────────────────────
 .it-cards-area {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-width: 1100px;
 }
 
 // ── Cards bar (title + expand/collapse all) ───────────────────────────────────
@@ -671,8 +543,6 @@ datalist { display: none; }
     overflow: hidden;
     min-height: 0;
 
-    // Force DnD-only monster cards (and JaD cards) to fill the slot width
-    // so the clickable header and the card body stay the same width.
     ::ng-deep .m-card,
     ::ng-deep .jmc-card {
       max-width: 100%;
@@ -687,35 +557,5 @@ datalist { display: none; }
   }
 }
 
-// ── Expand-all button ─────────────────────────────────────────────────────────
-.it-btn--expand-all {
-  background: transparent;
-  border: 1px solid rgba(255,255,255,.07);
-  color: rgba(255,255,255,.28);
-  padding: 4px 10px;
-
-  mat-icon { font-size: 13px; width: 13px; height: 13px; }
-
-  &:hover {
-    background: rgba(255,255,255,.04);
-    border-color: rgba(255,255,255,.14);
-    color: rgba(255,255,255,.6);
-  }
-}
-
-// ── Close-all button ──────────────────────────────────────────────────────────
-.it-btn--close-all {
-  background: transparent;
-  border: 1px solid rgba(180,50,40,.25);
-  color: rgba(200,80,70,.55);
-  padding: 4px 10px;
-
-  mat-icon { font-size: 13px; width: 13px; height: 13px; }
-
-  &:hover {
-    background: rgba(180,40,30,.1);
-    border-color: rgba(200,60,50,.5);
-    color: rgba(220,90,80,.85);
-  }
-}
-
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+@keyframes scaleIn { from { transform: scale(.92); opacity: 0; } to { transform: scale(1); opacity: 1; } }

--- a/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.scss
+++ b/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.scss
@@ -473,32 +473,32 @@ datalist { display: none; }
 }
 
 .it-card-slot__close {
+  width: 26px !important; height: 26px !important;
+  padding: 0 !important; line-height: 1 !important;
+  display: inline-flex !important;
+  align-items: center !important; justify-content: center !important;
   flex-shrink: 0;
-  width: 20px; height: 20px;
-  padding: 0;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 2px;
-  cursor: pointer;
-  color: rgba(255,255,255,.25);
-  font-size: 11px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: background .15s, color .15s, border-color .15s;
-  margin-left: 2px;
+  color: rgba(255,255,255,.15) !important;
+  border-radius: 1px !important;
+  transition: color .15s, background .15s !important;
+  margin-left: auto;
 
-  &:hover {
-    background: rgba(160,30,30,.2);
-    border-color: rgba(200,50,40,.4);
-    color: #f08070;
+  mat-icon, .mat-icon {
+    font-size: 15px !important; width: 15px !important;
+    height: 15px !important; line-height: 15px !important;
+    display: flex !important; align-items: center !important; justify-content: center !important;
   }
+
+  .mat-mdc-button-touch-target,
+  .mat-mdc-button-persistent-ripple,
+  .mdc-icon-button__ripple { display: none !important; }
+
+  &:hover { color: rgba(200,60,50,.9) !important; background: rgba(160,30,30,.1) !important; }
 }
 
 .it-card-slot__label {
   display: flex;
   align-items: center;
-  gap: 5px;
   font-family: sans-serif;
   font-size: 11px;
   letter-spacing: .02em;
@@ -507,26 +507,7 @@ datalist { display: none; }
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-}
-
-.it-card-slot__label-icon {
-  font-size: 13px !important;
-  width: 13px !important;
-  height: 13px !important;
-  color: rgba(160,30,30,.6);
-}
-
-.it-card-slot__chevron {
-  font-size: 16px !important;
-  width: 16px !important;
-  height: 16px !important;
-  color: rgba(255,255,255,.2);
-  transition: color .15s;
-  flex-shrink: 0;
-
-  .it-card-slot__header:hover & {
-    color: rgba(255,255,255,.5);
-  }
+  flex: 1;
 }
 
 // ── Animated body (grid-template-rows collapse trick) ─────────────────────────
@@ -538,10 +519,6 @@ datalist { display: none; }
   > .it-card-body {
     overflow: hidden;
     min-height: 0;
-    background: rgba(255,255,255,.02);
-    border: 1px solid rgba(255,255,255,.06);
-    border-top: none;
-    border-radius: 0 0 2px 2px;
 
     ::ng-deep .m-card,
     ::ng-deep .jmc-card {

--- a/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.ts
+++ b/libs/character-sheet/feature/src/lib/initiative-tracker/initiative-tracker.component.ts
@@ -67,6 +67,7 @@ const CARDS_STORAGE_KEY = INITIATIVE_TRACKER_CARDS_KEY;
   templateUrl: './initiative-tracker.component.html',
   styleUrl: './initiative-tracker.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { '(document:keydown.control.s)': 'ctrlSave($event)' },
   imports: [FormsModule, MatIconButton, MatIcon, MatTooltip, MonsterCardComponent, JadMonsterCardComponent, AutofillInputComponent],
 })
 export class InitiativeTrackerComponent {
@@ -283,6 +284,8 @@ export class InitiativeTrackerComponent {
     this.rows.update(r => [...r].sort((a, b) => (b.initiative ?? -Infinity) - (a.initiative ?? -Infinity)));
     this.activeIndex.set(0);
   }
+
+  ctrlSave(e: Event): void { e.preventDefault(); this.save(); }
 
   save() {
     this.localStorageService.setDataSync(STORAGE_KEY, this.rows());

--- a/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
@@ -52,14 +52,6 @@ import { debounceTime } from 'rxjs/operators';
     }
     @keyframes fadeBanner { from { opacity: 0; } to { opacity: 1; } }
 
-    .btn-save {
-      font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
-      border: 1px solid rgba(80,160,80,.35); border-radius: 3px; background: rgba(60,120,60,.08);
-      color: rgba(100,200,100,.8); padding: 6px 16px; cursor: pointer;
-      display: flex; align-items: center; gap: 6px; transition: background .18s, border-color .18s, color .18s;
-      mat-icon { font-size: 15px; width: 15px; height: 15px; }
-      &:hover { background: rgba(60,140,60,.18); border-color: rgba(80,180,80,.6); color: #80e080; }
-    }
 
     /* ── 2-column panel grid ─────────────────────── */
     .notes-grid {
@@ -164,7 +156,7 @@ import { debounceTime } from 'rxjs/operators';
         <span class="autosave-indicator" [class.autosave-indicator--hidden]="!autoSaved()">
           <mat-icon>check_circle</mat-icon> Automaticky uloženo
         </span>
-        <button class="btn-save" type="submit" (click)="onSaveClick()">
+        <button class="pt-filter-btn" type="submit" (click)="onSaveClick()">
             <mat-icon>save</mat-icon>Uložit
           </button>
       </div>

--- a/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
@@ -178,7 +178,7 @@ import { debounceTime } from 'rxjs/operators';
           <div class="panel-header">
             <mat-icon class="panel-icon">history_edu</mat-icon>
             <span class="panel-title">Zápisky z Výpravy</span>
-            <span class="panel-desc">Deník sezení, klíčové události</span>
+<!--            <span class="panel-desc">Deník sezení, klíčové události</span>-->
           </div>
           <div class="rt-wrap">
             <rich-textarea [formControl]="controls.notesColumn1" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
@@ -190,8 +190,8 @@ import { debounceTime } from 'rxjs/operators';
           <div class="panel-rule"></div>
           <div class="panel-header">
             <mat-icon class="panel-icon">explore</mat-icon>
-            <span class="panel-title">Mapy &amp; Místa</span>
-            <span class="panel-desc">Lokace, sklepy, popisky map</span>
+            <span class="panel-title">Questy</span>
+            <span class="panel-desc">Nebo záložka Questy pro větší přehled</span>
           </div>
           <div class="rt-wrap">
             <rich-textarea [formControl]="controls.notesColumn2" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
@@ -203,8 +203,8 @@ import { debounceTime } from 'rxjs/operators';
           <div class="panel-rule"></div>
           <div class="panel-header">
             <mat-icon class="panel-icon">psychology</mat-icon>
-            <span class="panel-title">Cíle &amp; Tajemství</span>
-            <span class="panel-desc">Otevřené otázky, plány, úkoly</span>
+            <span class="panel-title">Cizí Postavy, frakce, vztahy, ...</span>
+<!--            <span class="panel-desc">Otevřené otázky, plány, úkoly</span>-->
           </div>
           <div class="rt-wrap">
             <rich-textarea [formControl]="controls.notesColumn4" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>

--- a/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
@@ -161,20 +161,14 @@ import { debounceTime } from 'rxjs/operators';
   `,
   template: `
     <form [formGroup]="form">
-      <div class="header">
-        <div>
-          <div class="header-title"><mat-icon>auto_stories</mat-icon>Zápisník Dobrodruhů</div>
-          <div class="header-subtitle">Osobní zápisky, mapy a cíle tvojí postavy</div>
-        </div>
-        <div class="header-actions">
-          <span class="autosave-msg" [class.autosave-msg--hidden]="autoSaveStatus() !== 'saved'">✓ Uloženo</span>
-          <span class="autosave-indicator" [class.autosave-indicator--hidden]="!autoSaved()">
-            <mat-icon>check_circle</mat-icon> Automaticky uloženo
-          </span>
-          <button class="btn-save" type="submit" (click)="onSaveClick()">
+      <div class="header-actions">
+        <span class="autosave-msg" [class.autosave-msg--hidden]="autoSaveStatus() !== 'saved'">✓ Uloženo</span>
+        <span class="autosave-indicator" [class.autosave-indicator--hidden]="!autoSaved()">
+          <mat-icon>check_circle</mat-icon> Automaticky uloženo
+        </span>
+        <button class="btn-save" type="submit" (click)="onSaveClick()">
             <mat-icon>save</mat-icon>Uložit
           </button>
-        </div>
       </div>
 
       <div class="notes-grid">

--- a/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
@@ -94,7 +94,6 @@ import { debounceTime } from 'rxjs/operators';
       transition: border-color .2s, box-shadow .2s;
       position: relative;
       &:hover { border-color: rgba(200,160,60,.32); box-shadow: 0 6px 26px rgba(0,0,0,.6), 0 0 8px rgba(200,160,60,.06); }
-      &::before { content: '◆'; position: absolute; top: 5px; left: 8px; font-size: 6px; color: rgba(200,160,60,.2); pointer-events: none; }
     }
 
     .panel-rule { height: 2px; background: linear-gradient(90deg, rgba(200,160,60,0) 0%, rgba(200,160,60,.35) 40%, rgba(240,200,80,.6) 50%, rgba(200,160,60,.35) 60%, rgba(200,160,60,0) 100%); }

--- a/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
@@ -32,7 +32,7 @@ import { debounceTime } from 'rxjs/operators';
       mat-icon { font-size: 26px; width: 26px; height: 26px; color: #c8a03c; }
     }
     .header-subtitle { font-size: 11px; color: rgba(200,160,60,.4); letter-spacing: .05em; margin-top: 5px; font-family: sans-serif; font-style: italic; text-transform: none; }
-    .header-actions { display: flex; gap: 10px; align-items: center; }
+    .header-actions { display: flex; gap: 10px; align-items: center; justify-content: flex-end; flex-wrap: wrap; margin-bottom: 14px; }
 
     .autosave-indicator {
       font-family: sans-serif; font-size: 10px; letter-spacing: .05em;

--- a/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
@@ -96,7 +96,6 @@ import { debounceTime } from 'rxjs/operators';
       &:hover { border-color: rgba(200,160,60,.32); box-shadow: 0 6px 26px rgba(0,0,0,.6), 0 0 8px rgba(200,160,60,.06); }
     }
 
-    .panel-rule { height: 2px; background: linear-gradient(90deg, rgba(200,160,60,0) 0%, rgba(200,160,60,.35) 40%, rgba(240,200,80,.6) 50%, rgba(200,160,60,.35) 60%, rgba(200,160,60,0) 100%); }
 
     .panel-header {
       display: flex; align-items: center; gap: 8px;
@@ -173,7 +172,7 @@ import { debounceTime } from 'rxjs/operators';
       <div class="notes-grid">
         <!-- Zápisky z Výpravy — notesColumn1 (existing data preserved) -->
         <div class="note-panel panel--expedition">
-          <div class="panel-rule"></div>
+
           <div class="panel-header">
             <mat-icon class="panel-icon">history_edu</mat-icon>
             <span class="panel-title">Zápisky z Výpravy</span>
@@ -186,7 +185,7 @@ import { debounceTime } from 'rxjs/operators';
 
         <!-- Mapy & Místa — notesColumn2 (existing data preserved) -->
         <div class="note-panel panel--maps">
-          <div class="panel-rule"></div>
+
           <div class="panel-header">
             <mat-icon class="panel-icon">explore</mat-icon>
             <span class="panel-title">Questy</span>
@@ -199,7 +198,7 @@ import { debounceTime } from 'rxjs/operators';
 
         <!-- Cíle & Tajemství — notesColumn4 (new) -->
         <div class="note-panel panel--goals">
-          <div class="panel-rule"></div>
+
           <div class="panel-header">
             <mat-icon class="panel-icon">psychology</mat-icon>
             <span class="panel-title">Cizí Postavy, frakce, vztahy, ...</span>

--- a/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
+++ b/libs/character-sheet/feature/src/lib/notes-sheet.component.ts
@@ -16,7 +16,7 @@ import { debounceTime } from 'rxjs/operators';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [ReactiveFormsModule, RichTextareaComponent, MatIcon],
   styles: `
-    :host { display: block; padding: 24px 32px 40px; font-family: sans-serif; overflow: visible; }
+    :host { display: block; padding: 13px 0 20px; font-family: sans-serif; overflow: visible; }
 
     /* ── Header ─────────────────────────────────── */
     .header {
@@ -70,7 +70,7 @@ import { debounceTime } from 'rxjs/operators';
     }
 
     @media (max-width: 700px) {
-      :host { padding: 16px 12px 40px; }
+      :host { padding: 13px 0 20px; }
 
       .notes-grid {
         grid-template-columns: 1fr;

--- a/libs/character-sheet/feature/src/lib/potions-tab/potions-tab.component.ts
+++ b/libs/character-sheet/feature/src/lib/potions-tab/potions-tab.component.ts
@@ -919,7 +919,7 @@ const FAIL_TABLE: FailEntry[] = [
   `,
   styles: `
     :host { display: block; overflow-y: auto; height: calc(100svh - 165px); min-height: 400px; }
-    .pt-wrap { padding: 20px 28px 40px; max-width: 1200px; margin: 0 auto; font-family: sans-serif; color: #d4c9a0; }
+    .pt-wrap { padding: 20px 0 40px; max-width: 1200px; font-family: sans-serif; color: #d4c9a0; }
     .pt-header { margin-bottom: 16px; }
     .pt-title { font-size: 20px; color: #e8c96a; margin: 0 0 4px; font-weight: 600; }
     .pt-subtitle { font-size: 12px; color: #9a8a6a; margin: 0; }

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -34,7 +34,7 @@ const LS_FILTER_KEY = 'dnd_quests_filter';
   styles: `
     :host {
       display: block;
-      padding: 24px 32px 40px;
+      padding: 13px 0 20px;
       font-family: sans-serif;
     }
 

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -179,21 +179,12 @@ const LS_FILTER_KEY = 'dnd_quests_filter';
     .quest-card {
       position: relative;
       border-radius: 3px;
-      background: rgba(28,24,14,.97);
+      background: rgba(22,20,18,.97);
       border: 1px solid rgba(200,160,60,.15);
-      border-left: 3px solid transparent;
-      box-shadow: 0 4px 20px rgba(0,0,0,.5);
+      box-shadow: 0 4px 20px rgba(0,0,0,.55);
       overflow: visible;
-
-      &--completed {
-        background: rgba(20,28,14,.97);
-        border-color: rgba(80,160,80,.2);
-      }
-
-      &--failed {
-        background: rgba(28,14,12,.97);
-        border-color: rgba(160,60,50,.2);
-      }
+      transition: border-color .2s, box-shadow .2s;
+      &:hover { border-color: rgba(200,160,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65); }
     }
 
     /* ── Card header ───────────────────────────── */
@@ -208,22 +199,19 @@ const LS_FILTER_KEY = 'dnd_quests_filter';
 
     .status-badge {
       font-family: sans-serif;
-      font-size: 8px;
-      letter-spacing: .12em;
+      font-size: 9px;
+      letter-spacing: .1em;
       text-transform: uppercase;
-      border-radius: 10px;
-      padding: 2px 9px;
+      border-radius: 6px;
+      padding: 4px 12px;
       cursor: pointer;
-      border: 1px solid currentColor;
-      transition: opacity .15s, filter .15s;
       white-space: nowrap;
       flex-shrink: 0;
-      &:hover { filter: brightness(1.2); }
-
-      &--active   { color: rgba(80,190,100,.9); background: rgba(60,160,80,.12); }
-      &--completed { color: rgba(200,160,60,.9); background: rgba(200,160,60,.12); }
-      &--failed    { color: rgba(210,80,70,.9); background: rgba(180,50,40,.12); }
-      &--inactive  { color: rgba(140,140,140,.7); background: rgba(120,120,120,.08); }
+      background: rgba(200,160,60,.08);
+      border: 1px solid rgba(200,160,60,.2);
+      color: #9a8a6a;
+      transition: background .15s, border-color .15s, color .15s;
+      &:hover { background: rgba(200,160,60,.15); border-color: rgba(200,160,60,.4); color: #d4c9a0; }
     }
 
     .priority-dot {

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -638,32 +638,20 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
   template: `
     <spinner-overlay [showSpinner]="showSpinner()" [diameter]="50">
 
-      <!-- ── Header ──────────────────────────────────── -->
-      <div class="quests-header">
-        <div>
-          <div class="quests-title">
-            <mat-icon>menu_book</mat-icon>
-            Deník Dobrodružství
-          </div>
-          <div class="quests-subtitle">
-            Zaznamenej si questy, úkoly a dobrodružství, která tě čekají
-          </div>
-        </div>
-        <div class="quests-header-actions">
-          <span class="autosave-msg" [class.autosave-msg--hidden]="autoSaveStatus() !== 'saved'">✓ Uloženo</span>
-          <button class="btn-dnd btn-dnd-icon" type="button" (click)="toggleAllExpanded()"
-            [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
-            <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
-          </button>
-          <button class="btn-dnd" type="button" (click)="addQuest()" matTooltip="Přidat nový quest">
-            <mat-icon>add</mat-icon>
-            Přidat quest
-          </button>
-          <button class="btn-dnd btn-dnd-save" type="button" (click)="save(true)" matTooltip="Uložit questy do databáze">
+      <div class="quests-header-actions">
+        <span class="autosave-msg" [class.autosave-msg--hidden]="autoSaveStatus() !== 'saved'">✓ Uloženo</span>
+        <button class="btn-dnd btn-dnd-icon" type="button" (click)="toggleAllExpanded()"
+          [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
+          <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+        </button>
+        <button class="btn-dnd" type="button" (click)="addQuest()" matTooltip="Přidat nový quest">
+          <mat-icon>add</mat-icon>
+          Přidat quest
+        </button>
+        <button class="btn-dnd btn-dnd-save" type="button" (click)="save(true)" matTooltip="Uložit questy do databáze">
             <mat-icon>save</mat-icon>
             Uložit
           </button>
-        </div>
       </div>
 
       <!-- ── Filter + sort bar ───────────────────────── -->

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -138,29 +138,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
       flex-wrap: wrap;
     }
 
-    .filter-tab {
-      font-family: sans-serif;
-      font-size: 10px;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-      border: 1px solid rgba(255,255,255,.07);
-      border-radius: 2px;
-      background: transparent;
-      color: rgba(255,255,255,.3);
-      padding: 4px 12px;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      transition: background .15s, border-color .15s, color .15s;
-      &:hover { background: rgba(255,255,255,.05); color: rgba(255,255,255,.55); }
-      &--active {
-        background: rgba(200,160,60,.12);
-        border-color: rgba(200,160,60,.45);
-        color: #e8c96a;
-      }
-    }
-
     .filter-count {
       background: rgba(255,255,255,.08);
       border-radius: 10px;
@@ -567,9 +544,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
       min-width: 300px;
       max-width: 400px;
       animation: scaleIn .14s ease;
-
-      &::before { content: '◆'; position: absolute; top: 7px; left: 9px; font-size: 7px; color: rgba(200,160,60,.4); pointer-events: none; }
-      &::after  { content: '◆'; position: absolute; bottom: 7px; right: 9px; font-size: 7px; color: rgba(200,160,60,.4); pointer-events: none; }
     }
 
     .confirm-icon { display: flex; justify-content: center; margin-bottom: 12px;
@@ -644,8 +618,8 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
           @for (tab of filterTabs; track tab.value) {
             <button
               type="button"
-              class="filter-tab"
-              [class.filter-tab--active]="filterStatus() === tab.value"
+              class="pt-filter-btn"
+              [class.active]="filterStatus() === tab.value"
               (click)="filterStatus.set(tab.value)"
             >
               {{ tab.label }}

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -13,7 +13,7 @@ import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
 import { CharacterSheetStore } from '@dn-d-servant/character-sheet-data-access';
 import { AuthService } from '@dn-d-servant/util';
-import { QuestEntry, QuestPriority, QuestStatus } from '@dn-d-servant/character-sheet-util';
+import { QuestEntry, QuestStatus } from '@dn-d-servant/character-sheet-util';
 import { SpinnerOverlayComponent, RichTextareaComponent } from '@dn-d-servant/ui';
 import { DOCUMENT } from '@angular/common';
 import { Subject } from 'rxjs';
@@ -21,7 +21,6 @@ import { debounceTime } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 type FilterStatus = 'all' | QuestStatus;
-type SortMode = 'priority' | 'date';
 
 const LS_QUESTS_KEY = 'dnd_quests_draft';
 const LS_EXPANDED_KEY = 'dnd_quests_expanded';
@@ -150,28 +149,7 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
     }
 
     .sort-tabs {
-      display: flex;
-      gap: 4px;
-    }
-
-    .sort-btn {
-      font-family: sans-serif;
-      font-size: 9px;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-      border: 1px solid rgba(255,255,255,.06);
-      border-radius: 2px;
-      background: transparent;
-      color: rgba(255,255,255,.25);
-      padding: 4px 10px;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      gap: 5px;
-      transition: background .15s, color .15s;
-      mat-icon { font-size: 13px; width: 13px; height: 13px; }
-      &:hover { background: rgba(255,255,255,.04); color: rgba(255,255,255,.5); }
-      &--active { color: rgba(200,160,60,.75); border-color: rgba(200,160,60,.25); }
+      display: none;
     }
 
     /* ── Quest grid ────────────────────────────── */
@@ -255,18 +233,7 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
     }
 
     .priority-dot {
-      width: 9px; height: 9px;
-      border-radius: 50%;
-      flex-shrink: 0;
-      cursor: pointer;
-      transition: transform .15s, filter .15s;
-      border: 1px solid rgba(255,255,255,.15);
-      &:hover { transform: scale(1.35); filter: brightness(1.3); }
-
-      &--critical { background: rgba(180,30,30,.9); box-shadow: 0 0 6px rgba(180,30,30,.5); }
-      &--high     { background: rgba(200,100,30,.9); box-shadow: 0 0 6px rgba(200,100,30,.4); }
-      &--medium   { background: rgba(200,160,60,.9); box-shadow: 0 0 6px rgba(200,160,60,.35); }
-      &--low      { background: rgba(80,120,180,.85); box-shadow: 0 0 6px rgba(80,120,180,.3); }
+      display: none;
     }
 
     .quest-date {
@@ -505,14 +472,7 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
             </button>
           }
         </div>
-        <div class="sort-tabs">
-          <button type="button" class="sort-btn" [class.sort-btn--active]="sortMode() === 'priority'" (click)="sortMode.set('priority')">
-            <mat-icon>priority_high</mat-icon> Priorita
-          </button>
-          <button type="button" class="sort-btn" [class.sort-btn--active]="sortMode() === 'date'" (click)="sortMode.set('date')">
-            <mat-icon>calendar_today</mat-icon> Datum
-          </button>
-        </div>
+        <div class="sort-tabs"></div>
         <div class="quests-bar-actions">
           <span class="autosave-msg" [class.autosave-msg--hidden]="autoSaveStatus() !== 'saved'">✓ Uloženo</span>
           <button class="btn-dnd btn-dnd-icon" type="button" (click)="toggleAllExpanded()"
@@ -544,7 +504,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
             class="quest-card"
             [class.quest-card--completed]="item.quest.status === 'completed'"
             [class.quest-card--failed]="item.quest.status === 'failed'"
-            [style.border-left-color]="priorityColor(item.quest.priority)"
           >
             <!-- Header row -->
             <div class="quest-card-header" (click)="toggleExpand(item.quest.id)">
@@ -554,11 +513,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
                 (click)="cycleStatus(item.idx); $event.stopPropagation()"
                 matTooltip="Klikni pro změnu stavu"
               >{{ statusLabel(item.quest.status) }}</button>
-              <span
-                class="priority-dot priority-dot--{{ item.quest.priority }}"
-                (click)="cyclePriority(item.idx); $event.stopPropagation()"
-                [matTooltip]="'Priorita: ' + priorityLabel(item.quest.priority) + ' — klikni pro změnu'"
-              ></span>
               <span class="quest-date">{{ item.quest.dateAdded }}</span>
               <div class="quest-card-btns">
                 <button
@@ -656,7 +610,6 @@ export class QuestsTabComponent {
 
   quests = signal<QuestEntry[]>([]);
   filterStatus = signal<FilterStatus>('all');
-  sortMode = signal<SortMode>('priority');
   expandedIds = signal<Set<string>>(new Set(this._loadExpandedIds()));
   confirmDeleteIndex = signal<number | null>(null);
 
@@ -681,20 +634,11 @@ export class QuestsTabComponent {
 
   readonly filteredAndSorted = computed(() => {
     const fs = this.filterStatus();
-    const sm = this.sortMode();
     let filtered = this.quests().map((quest, idx) => ({ quest, idx }));
     if (fs !== 'all') {
       filtered = filtered.filter(({ quest }) => quest.status === fs);
     }
-    const priorityOrder: Record<QuestPriority, number> = { critical: 0, high: 1, medium: 2, low: 3 };
-    if (sm === 'priority') {
-      filtered.sort((a, b) => {
-        const pd = priorityOrder[a.quest.priority] - priorityOrder[b.quest.priority];
-        return pd !== 0 ? pd : b.quest.dateAdded.localeCompare(a.quest.dateAdded);
-      });
-    } else {
-      filtered.sort((a, b) => b.quest.dateAdded.localeCompare(a.quest.dateAdded));
-    }
+    filtered.sort((a, b) => b.quest.dateAdded.localeCompare(a.quest.dateAdded));
     return filtered;
   });
 
@@ -785,7 +729,6 @@ export class QuestsTabComponent {
       description: '',
       imageBase64: null,
       status: 'active',
-      priority: 'medium',
       rewards: '',
       npcName: '',
       location: '',
@@ -837,18 +780,6 @@ export class QuestsTabComponent {
     this.scheduleAutoSave();
   }
 
-  cyclePriority(idx: number): void {
-    const order: QuestPriority[] = ['critical', 'high', 'medium', 'low'];
-    this.quests.update(list =>
-      list.map((q, i) => {
-        if (i !== idx) return q;
-        const next = order[(order.indexOf(q.priority) + 1) % order.length];
-        return { ...q, priority: next };
-      }),
-    );
-    this.scheduleAutoSave();
-  }
-
   askDelete(idx: number): void {
     this.confirmDeleteIndex.set(idx);
   }
@@ -888,16 +819,6 @@ export class QuestsTabComponent {
 
   // ── Display helpers ───────────────────────────────────────────────────────
 
-  priorityColor(priority: QuestPriority): string {
-    const map: Record<QuestPriority, string> = {
-      critical: 'rgba(180,30,30,.9)',
-      high: 'rgba(200,100,30,.9)',
-      medium: 'rgba(200,160,60,.9)',
-      low: 'rgba(80,120,180,.85)',
-    };
-    return map[priority];
-  }
-
   statusLabel(status: QuestStatus): string {
     const map: Record<QuestStatus, string> = {
       active: 'Aktivní',
@@ -908,15 +829,6 @@ export class QuestsTabComponent {
     return map[status];
   }
 
-  priorityLabel(priority: QuestPriority): string {
-    const map: Record<QuestPriority, string> = {
-      critical: 'Kritická',
-      high: 'Vysoká',
-      medium: 'Střední',
-      low: 'Nízká',
-    };
-    return map[priority];
-  }
 
   // ── LocalStorage helpers ──────────────────────────────────────────────────
 

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -541,22 +541,21 @@ const LS_FILTER_KEY = 'dnd_quests_filter';
                 <div class="quest-meta-row">
                   <div class="quest-meta-field">
                     <mat-icon class="quest-meta-icon">person</mat-icon>
-                    <input class="quest-meta-input" [(ngModel)]="quests()[item.idx].npcName" (ngModelChange)="scheduleAutoSave()" placeholder="NPC / Zadavatel" />
+                    <input class="quest-meta-input" [(ngModel)]="quests()[item.idx].npcName" (ngModelChange)="scheduleAutoSave()" placeholder="Kdo quest zadal..." />
                   </div>
                   <div class="quest-meta-field">
                     <mat-icon class="quest-meta-icon">place</mat-icon>
-                    <input class="quest-meta-input" [(ngModel)]="quests()[item.idx].location" (ngModelChange)="scheduleAutoSave()" placeholder="Lokalita / Oblast" />
+                    <input class="quest-meta-input" [(ngModel)]="quests()[item.idx].location" (ngModelChange)="scheduleAutoSave()" placeholder="Lokalita / Oblast..." />
                   </div>
                   <div class="quest-meta-field">
                     <mat-icon class="quest-meta-icon" style="color:rgba(200,160,60,.55)">payments</mat-icon>
-                    <input class="quest-meta-input quest-meta-input--gold" [(ngModel)]="quests()[item.idx].rewards" (ngModelChange)="scheduleAutoSave()" placeholder="Odměna, zkušenosti, předměty..." />
+                    <input class="quest-meta-input quest-meta-input--gold" [(ngModel)]="quests()[item.idx].rewards" (ngModelChange)="scheduleAutoSave()" placeholder="Odměna..." />
                   </div>
                 </div>
 
                 <!-- Rich notes -->
                 <div class="quest-section-label">
-                  <mat-icon>notes</mat-icon>
-                  Zápisky &amp; Postup
+                  Zápisky
                 </div>
                 <div class="quest-desc-wrap">
                   <rich-textarea

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -182,13 +182,7 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
       border: 1px solid rgba(200,160,60,.15);
       border-left: 3px solid transparent;
       box-shadow: 0 4px 20px rgba(0,0,0,.5);
-      transition: border-color .2s, box-shadow .2s;
       overflow: visible;
-
-      &:hover {
-        border-color: rgba(200,160,60,.3);
-        box-shadow: 0 6px 28px rgba(0,0,0,.65);
-      }
 
       &--completed {
         background: rgba(20,28,14,.97);
@@ -208,8 +202,7 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
       gap: 6px;
       padding: 8px 10px 6px;
       cursor: pointer;
-      transition: background .15s;
-      &:hover { background: rgba(200,160,60,.04); }
+      &:hover { background: rgba(255,255,255,.02); }
     }
 
     .status-badge {

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -30,7 +30,7 @@ const LS_FILTER_KEY = 'dnd_quests_filter';
   selector: 'quests-tab',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormsModule, MatIcon, MatIconButton, MatTooltip, SpinnerOverlayComponent, RichTextareaComponent],
-  host: { '(document:keydown.escape)': 'onEscape()' },
+  host: { '(document:keydown.escape)': 'onEscape()', '(document:keydown.control.s)': 'ctrlSave($event)' },
   styles: `
     :host {
       display: block;
@@ -803,6 +803,7 @@ export class QuestsTabComponent {
       this.cancelDelete();
     }
   }
+  ctrlSave(e: Event): void { e.preventDefault(); this.save(true); }
 
   // ── Display helpers ───────────────────────────────────────────────────────
 

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -24,6 +24,7 @@ type FilterStatus = 'all' | QuestStatus;
 
 const LS_QUESTS_KEY = 'dnd_quests_draft';
 const LS_EXPANDED_KEY = 'dnd_quests_expanded';
+const LS_FILTER_KEY = 'dnd_quests_filter';
 
 @Component({
   selector: 'quests-tab',
@@ -602,7 +603,7 @@ export class QuestsTabComponent {
   private readonly _doc = inject(DOCUMENT);
 
   quests = signal<QuestEntry[]>([]);
-  filterStatus = signal<FilterStatus>('all');
+  filterStatus = signal<FilterStatus>(this._loadFilterStatus());
   expandedIds = signal<Set<string>>(new Set(this._loadExpandedIds()));
   confirmDeleteIndex = signal<number | null>(null);
 
@@ -682,6 +683,12 @@ export class QuestsTabComponent {
           this._doc.defaultView?.localStorage.setItem(LS_EXPANDED_KEY, JSON.stringify([...ids]));
         } catch { /* quota exceeded — ignore */ }
       });
+    });
+
+    // ── Auto-persist selected filter to localStorage ───────────────────────
+    effect(() => {
+      const fs = this.filterStatus();
+      try { this._doc.defaultView?.localStorage.setItem(LS_FILTER_KEY, fs); } catch { /* ignore */ }
     });
 
     // ── Auto-save quests with debounce (2.5 s after last user change) ────
@@ -840,6 +847,16 @@ export class QuestsTabComponent {
       return raw ? (JSON.parse(raw) as string[]) : [];
     } catch {
       return [];
+    }
+  }
+
+  private _loadFilterStatus(): FilterStatus {
+    const valid: FilterStatus[] = ['all', 'active', 'completed', 'failed', 'inactive'];
+    try {
+      const raw = this._doc.defaultView?.localStorage.getItem(LS_FILTER_KEY) as FilterStatus;
+      return valid.includes(raw) ? raw : 'all';
+    } catch {
+      return 'all';
     }
   }
 }

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -79,13 +79,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
       text-transform: none;
     }
 
-    .quests-header-actions {
-      display: flex;
-      gap: 8px;
-      align-items: center;
-      flex-wrap: wrap;
-    }
-
     /* ── Buttons ───────────────────────────────── */
     .btn-dnd {
       font-family: sans-serif;
@@ -125,10 +118,18 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
     .quests-filter-bar {
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: flex-start;
       flex-wrap: wrap;
       gap: 10px;
       margin-bottom: 20px;
+    }
+
+    .quests-bar-actions {
+      margin-left: auto;
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: wrap;
     }
 
     .filter-tabs {
@@ -638,23 +639,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
   template: `
     <spinner-overlay [showSpinner]="showSpinner()" [diameter]="50">
 
-      <div class="quests-header-actions">
-        <span class="autosave-msg" [class.autosave-msg--hidden]="autoSaveStatus() !== 'saved'">✓ Uloženo</span>
-        <button class="btn-dnd btn-dnd-icon" type="button" (click)="toggleAllExpanded()"
-          [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
-          <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
-        </button>
-        <button class="btn-dnd" type="button" (click)="addQuest()" matTooltip="Přidat nový quest">
-          <mat-icon>add</mat-icon>
-          Přidat quest
-        </button>
-        <button class="btn-dnd btn-dnd-save" type="button" (click)="save(true)" matTooltip="Uložit questy do databáze">
-            <mat-icon>save</mat-icon>
-            Uložit
-          </button>
-      </div>
-
-      <!-- ── Filter + sort bar ───────────────────────── -->
       <div class="quests-filter-bar">
         <div class="filter-tabs">
           @for (tab of filterTabs; track tab.value) {
@@ -675,6 +659,21 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
           </button>
           <button type="button" class="sort-btn" [class.sort-btn--active]="sortMode() === 'date'" (click)="sortMode.set('date')">
             <mat-icon>calendar_today</mat-icon> Datum
+          </button>
+        </div>
+        <div class="quests-bar-actions">
+          <span class="autosave-msg" [class.autosave-msg--hidden]="autoSaveStatus() !== 'saved'">✓ Uloženo</span>
+          <button class="btn-dnd btn-dnd-icon" type="button" (click)="toggleAllExpanded()"
+            [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
+            <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+          </button>
+          <button class="btn-dnd" type="button" (click)="addQuest()" matTooltip="Přidat nový quest">
+            <mat-icon>add</mat-icon>
+            Přidat quest
+          </button>
+          <button class="btn-dnd btn-dnd-save" type="button" (click)="save(true)" matTooltip="Uložit questy do databáze">
+            <mat-icon>save</mat-icon>
+            Uložit
           </button>
         </div>
       </div>

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -76,40 +76,6 @@ const LS_FILTER_KEY = 'dnd_quests_filter';
       text-transform: none;
     }
 
-    /* ── Buttons ───────────────────────────────── */
-    .btn-dnd {
-      font-family: sans-serif;
-      font-size: 11px;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-      border: 1px solid rgba(200,160,60,.35);
-      border-radius: 3px;
-      background: rgba(200,160,60,.08);
-      color: rgba(200,160,60,.8);
-      padding: 6px 14px;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      gap: 5px;
-      transition: background .18s, border-color .18s, color .18s;
-      mat-icon { font-size: 15px; width: 15px; height: 15px; }
-      &:hover {
-        background: rgba(200,160,60,.16);
-        border-color: rgba(200,160,60,.6);
-        color: #e8c96a;
-      }
-    }
-
-    .btn-dnd-icon {
-      padding: 6px 10px;
-    }
-
-    .btn-dnd-save {
-      border-color: rgba(80,160,80,.35);
-      color: rgba(100,200,100,.8);
-      background: rgba(60,120,60,.08);
-      &:hover { background: rgba(60,140,60,.18); border-color: rgba(80,180,80,.6); color: #80e080; }
-    }
 
     /* ── Filter + sort bar ─────────────────────── */
     .quests-filter-bar {
@@ -457,15 +423,15 @@ const LS_FILTER_KEY = 'dnd_quests_filter';
         <div class="sort-tabs"></div>
         <div class="quests-bar-actions">
           <span class="autosave-msg" [class.autosave-msg--hidden]="autoSaveStatus() !== 'saved'">✓ Uloženo</span>
-          <button class="btn-dnd btn-dnd-icon" type="button" (click)="toggleAllExpanded()"
+          <button class="pt-filter-btn" type="button" (click)="toggleAllExpanded()"
             [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
             <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
           </button>
-          <button class="btn-dnd" type="button" (click)="addQuest()" matTooltip="Přidat nový quest">
+          <button class="pt-filter-btn" type="button" (click)="addQuest()" matTooltip="Přidat nový quest">
             <mat-icon>add</mat-icon>
             Přidat quest
           </button>
-          <button class="btn-dnd btn-dnd-save" type="button" (click)="save(true)" matTooltip="Uložit questy do databáze">
+          <button class="pt-filter-btn" type="button" (click)="save(true)" matTooltip="Uložit questy do databáze">
             <mat-icon>save</mat-icon>
             Uložit
           </button>

--- a/libs/character-sheet/feature/src/lib/quests/quests.component.ts
+++ b/libs/character-sheet/feature/src/lib/quests/quests.component.ts
@@ -3,11 +3,9 @@ import {
   Component,
   computed,
   effect,
-  ElementRef,
   inject,
   signal,
   untracked,
-  viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatIcon } from '@angular/material/icon';
@@ -17,7 +15,6 @@ import { CharacterSheetStore } from '@dn-d-servant/character-sheet-data-access';
 import { AuthService } from '@dn-d-servant/util';
 import { QuestEntry, QuestPriority, QuestStatus } from '@dn-d-servant/character-sheet-util';
 import { SpinnerOverlayComponent, RichTextareaComponent } from '@dn-d-servant/ui';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { DOCUMENT } from '@angular/common';
 import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
@@ -203,44 +200,27 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
     .quest-card {
       position: relative;
       border-radius: 3px;
-      background: linear-gradient(160deg, rgba(42,32,14,.97) 0%, rgba(28,20,8,.99) 100%);
+      background: rgba(28,24,14,.97);
       border: 1px solid rgba(200,160,60,.15);
       border-left: 3px solid transparent;
-      box-shadow: 0 4px 20px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,220,100,.04);
+      box-shadow: 0 4px 20px rgba(0,0,0,.5);
       transition: border-color .2s, box-shadow .2s;
       overflow: visible;
 
-      &::before {
-        content: '◆';
-        position: absolute;
-        top: 5px; left: 8px;
-        font-size: 6px;
-        color: rgba(200,160,60,.25);
-        pointer-events: none;
-      }
-
       &:hover {
         border-color: rgba(200,160,60,.3);
-        box-shadow: 0 6px 28px rgba(0,0,0,.65), 0 0 10px rgba(200,160,60,.06), inset 0 1px 0 rgba(255,220,100,.06);
+        box-shadow: 0 6px 28px rgba(0,0,0,.65);
       }
 
       &--completed {
-        background: linear-gradient(160deg, rgba(30,42,20,.97) 0%, rgba(18,28,10,.99) 100%);
+        background: rgba(20,28,14,.97);
         border-color: rgba(80,160,80,.2);
       }
 
       &--failed {
-        background: linear-gradient(160deg, rgba(42,18,14,.97) 0%, rgba(28,10,8,.99) 100%);
+        background: rgba(28,14,12,.97);
         border-color: rgba(160,60,50,.2);
       }
-    }
-
-    .quest-card-rule {
-      height: 2px;
-      background: linear-gradient(90deg,
-        rgba(200,160,60,.0) 0%, rgba(200,160,60,.4) 30%,
-        rgba(240,200,80,.7) 50%, rgba(200,160,60,.4) 70%,
-        rgba(200,160,60,.0) 100%);
     }
 
     /* ── Card header ───────────────────────────── */
@@ -356,77 +336,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
     .quest-expanded-body {
       padding: 0 12px 14px;
     }
-
-    /* ── Image area ────────────────────────────── */
-    .quest-image-wrap {
-      position: relative;
-      height: 130px;
-      background:
-        repeating-linear-gradient(45deg, rgba(200,160,60,.02) 0px, rgba(200,160,60,.02) 1px, transparent 1px, transparent 8px),
-        rgba(14,10,4,.5);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      overflow: hidden;
-      cursor: pointer;
-      border-bottom: 1px solid rgba(200,160,60,.08);
-      transition: background .18s;
-
-      img { width: 100%; height: 100%; object-fit: cover; display: block; }
-
-      .image-placeholder {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 6px;
-        color: rgba(200,160,60,.22);
-        font-size: 9px;
-        letter-spacing: .1em;
-        text-transform: uppercase;
-        pointer-events: none;
-        mat-icon { font-size: 28px; width: 28px; height: 28px; }
-      }
-
-      .image-overlay {
-        position: absolute;
-        inset: 0;
-        background: rgba(0,0,0,.5);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        opacity: 0;
-        transition: opacity .18s;
-        pointer-events: none;
-        mat-icon { color: #e8c96a; font-size: 24px; width: 24px; height: 24px; }
-      }
-      &:hover .image-overlay { opacity: 1; }
-
-      &.drag-over {
-        background:
-          repeating-linear-gradient(45deg, rgba(200,160,60,.06) 0px, rgba(200,160,60,.06) 1px, transparent 1px, transparent 8px),
-          rgba(30,22,8,.85);
-        box-shadow: inset 0 0 0 2px rgba(200,160,60,.5);
-        .image-overlay { opacity: 1; background: rgba(200,160,60,.1); }
-      }
-    }
-
-    .quest-img-view-btn {
-      position: absolute;
-      top: 5px; right: 5px;
-      z-index: 2;
-      width: 24px !important; height: 24px !important;
-      padding: 0 !important;
-      background: rgba(0,0,0,.6) !important;
-      color: rgba(200,160,60,.8) !important;
-      border-radius: 2px !important;
-      display: inline-flex !important;
-      align-items: center !important; justify-content: center !important;
-      mat-icon, .mat-icon { font-size: 13px !important; width: 13px !important; height: 13px !important; }
-      .mat-mdc-button-touch-target, .mat-mdc-button-persistent-ripple, .mdc-icon-button__ripple { display: none !important; }
-      &:hover { background: rgba(0,0,0,.85) !important; color: #e8c96a !important; }
-    }
-
-    .image-file-input { display: none; }
 
     /* ── Meta row ──────────────────────────────── */
     .quest-meta-row {
@@ -566,37 +475,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
       &:hover { background: rgba(180,40,30,.45); border-color: rgba(220,80,60,.7); color: #ff9980; }
     }
 
-    /* ── Full-scale image preview ──────────────── */
-    .img-preview-backdrop {
-      position: fixed; inset: 0; z-index: 9999;
-      background: rgba(0,0,0,.88);
-      display: flex; align-items: center; justify-content: center;
-      cursor: zoom-out; animation: fadeIn .18s ease;
-    }
-    .img-preview-container {
-      position: relative; max-width: 90vw; max-height: 88vh;
-      cursor: default; display: flex; flex-direction: column; align-items: center;
-      animation: scaleIn .18s ease;
-    }
-    .img-preview-title { font-family: sans-serif; font-size: 13px; letter-spacing: .12em; text-transform: uppercase; color: #e8c96a; text-shadow: 0 0 12px rgba(200,160,60,.4); margin-bottom: 12px; }
-    .img-preview-frame {
-      border: 1px solid rgba(200,160,60,.35);
-      box-shadow: 0 0 0 1px rgba(0,0,0,.8), 0 8px 40px rgba(0,0,0,.9), 0 0 60px rgba(200,160,60,.08);
-      background: rgba(14,10,4,.95); padding: 6px;
-      img { display: block; max-width: 88vw; max-height: 78vh; object-fit: contain; }
-    }
-    .img-preview-close {
-      position: absolute; top: -14px; right: -14px;
-      width: 28px !important; height: 28px !important; padding: 0 !important;
-      background: rgba(40,28,10,.98) !important; border: 1px solid rgba(200,160,60,.4) !important;
-      color: #c8a03c !important; border-radius: 3px !important;
-      display: inline-flex !important; align-items: center !important; justify-content: center !important;
-      mat-icon, .mat-icon { font-size: 15px !important; width: 15px !important; height: 15px !important; display: flex !important; align-items: center !important; justify-content: center !important; }
-      .mat-mdc-button-touch-target, .mat-mdc-button-persistent-ripple, .mdc-icon-button__ripple { display: none !important; }
-      &:hover { background: rgba(200,160,60,.15) !important; color: #e8c96a !important; }
-    }
-    .img-preview-hint { margin-top: 10px; font-size: 10px; color: rgba(200,160,60,.3); letter-spacing: .1em; }
-
     /* ── Auto-save indicator ─────────────────── */
     .autosave-msg {
       font-family: sans-serif;
@@ -668,8 +546,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
             [class.quest-card--failed]="item.quest.status === 'failed'"
             [style.border-left-color]="priorityColor(item.quest.priority)"
           >
-            <div class="quest-card-rule"></div>
-
             <!-- Header row -->
             <div class="quest-card-header" (click)="toggleExpand(item.quest.id)">
               <button
@@ -713,39 +589,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
             <!-- Expanded body -->
             @if (expandedIds().has(item.quest.id)) {
               <div class="quest-expanded-body">
-                <!-- Image drop zone -->
-                <div
-                  class="quest-image-wrap"
-                  [class.drag-over]="dragOverIndex() === item.idx"
-                  (click)="selectImage(item.idx)"
-                  (dragover)="onDragOver($event, item.idx)"
-                  (dragleave)="onDragLeave()"
-                  (drop)="onDrop($event, item.idx)"
-                  matTooltip="Klikni nebo přetáhni obrázek questu (max 200 KB)"
-                >
-                  @if (quests()[item.idx].imageBase64) {
-                    <img
-                      [src]="'data:image/png;base64,' + quests()[item.idx].imageBase64"
-                      [alt]="quests()[item.idx].title"
-                    />
-                    <button
-                      mat-icon-button
-                      class="quest-img-view-btn"
-                      type="button"
-                      (click)="openPreview($event, quests()[item.idx])"
-                      matTooltip="Zobrazit v plné velikosti"
-                    >
-                      <mat-icon>open_in_full</mat-icon>
-                    </button>
-                  } @else {
-                    <div class="image-placeholder">
-                      <mat-icon>image_search</mat-icon>
-                      Klikni nebo přetáhni obrázek
-                    </div>
-                  }
-                  <div class="image-overlay"><mat-icon>upload</mat-icon></div>
-                </div>
-
                 <!-- Meta fields -->
                 <div class="quest-meta-row">
                   <div class="quest-meta-field">
@@ -781,9 +624,6 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
       </div>
     </spinner-overlay>
 
-    <!-- Single hidden file input for image selection -->
-    <input #globalFileInput type="file" accept="image/*" class="image-file-input" (change)="onImageSelected($event)" />
-
     <!-- Confirm delete dialog -->
     @if (confirmDeleteIndex() !== null) {
       <div class="confirm-backdrop" (click)="cancelDelete()">
@@ -807,29 +647,11 @@ const LS_EXPANDED_KEY = 'dnd_quests_expanded';
       </div>
     }
 
-    <!-- Full-scale image preview -->
-    @if (previewQuest()) {
-      <div class="img-preview-backdrop" (click)="closePreview()">
-        <div class="img-preview-container" (click)="$event.stopPropagation()">
-          <button mat-icon-button type="button" class="img-preview-close" (click)="closePreview()" matTooltip="Zavřít">
-            <mat-icon>close</mat-icon>
-          </button>
-          @if (previewQuest()!.title) {
-            <div class="img-preview-title">{{ previewQuest()!.title }}</div>
-          }
-          <div class="img-preview-frame">
-            <img [src]="'data:image/png;base64,' + previewQuest()!.imageBase64" [alt]="previewQuest()!.title" />
-          </div>
-          <div class="img-preview-hint">Klikni mimo obrázek nebo stiskni Esc pro zavření</div>
-        </div>
-      </div>
-    }
   `,
 })
 export class QuestsTabComponent {
   readonly store = inject(CharacterSheetStore);
   private readonly authService = inject(AuthService);
-  private readonly snackBar = inject(MatSnackBar);
   private readonly _doc = inject(DOCUMENT);
 
   quests = signal<QuestEntry[]>([]);
@@ -837,11 +659,6 @@ export class QuestsTabComponent {
   sortMode = signal<SortMode>('priority');
   expandedIds = signal<Set<string>>(new Set(this._loadExpandedIds()));
   confirmDeleteIndex = signal<number | null>(null);
-  dragOverIndex = signal<number | null>(null);
-  previewQuest = signal<QuestEntry | null>(null);
-  private pendingFileIdx = signal<number | null>(null);
-
-  private readonly globalFileInput = viewChild<ElementRef<HTMLInputElement>>('globalFileInput');
 
   readonly filterTabs: { value: FilterStatus; label: string }[] = [
     { value: 'all', label: 'Vše' },
@@ -1064,74 +881,9 @@ export class QuestsTabComponent {
   }
 
   onEscape(): void {
-    if (this.previewQuest()) {
-      this.closePreview();
-    } else if (this.confirmDeleteIndex() !== null) {
+    if (this.confirmDeleteIndex() !== null) {
       this.cancelDelete();
     }
-  }
-
-  // ── Image handling ────────────────────────────────────────────────────────
-
-  selectImage(idx: number): void {
-    this.pendingFileIdx.set(idx);
-    this.globalFileInput()?.nativeElement.click();
-  }
-
-  onDragOver(event: DragEvent, idx: number): void {
-    event.preventDefault();
-    event.stopPropagation();
-    this.dragOverIndex.set(idx);
-  }
-
-  onDragLeave(): void {
-    this.dragOverIndex.set(null);
-  }
-
-  onDrop(event: DragEvent, idx: number): void {
-    event.preventDefault();
-    event.stopPropagation();
-    this.dragOverIndex.set(null);
-    const file = event.dataTransfer?.files[0];
-    if (file) this._processImageFile(file, idx);
-  }
-
-  onImageSelected(event: Event): void {
-    const idx = this.pendingFileIdx();
-    if (idx === null) return;
-    const file = (event.target as HTMLInputElement).files?.[0];
-    if (file) this._processImageFile(file, idx);
-    (event.target as HTMLInputElement).value = '';
-    this.pendingFileIdx.set(null);
-  }
-
-  private _processImageFile(file: File, idx: number): void {
-    if (file.size > 200 * 1024) {
-      this.snackBar.open('Obrázek je příliš velký (max 200 KB)', 'Zavřít', {
-        verticalPosition: 'top',
-        duration: 3000,
-      });
-      return;
-    }
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const result = e.target?.result as string;
-      const base64 = result.split(',')[1] ?? result;
-      this.quests.update(list =>
-        list.map((q, i) => (i === idx ? { ...q, imageBase64: base64 } : q)),
-      );
-      this.scheduleAutoSave();
-    };
-    reader.readAsDataURL(file);
-  }
-
-  openPreview(event: MouseEvent, quest: QuestEntry): void {
-    event.stopPropagation();
-    this.previewQuest.set(quest);
-  }
-
-  closePreview(): void {
-    this.previewQuest.set(null);
   }
 
   // ── Display helpers ───────────────────────────────────────────────────────

--- a/libs/character-sheet/feature/src/lib/spell-detail-dialog.component.ts
+++ b/libs/character-sheet/feature/src/lib/spell-detail-dialog.component.ts
@@ -25,7 +25,7 @@ export interface SpellDetailDialogData {
       flex-direction: column;
       max-height: 80vh;
       width: min(820px, 95vw);
-      background: #0d0b1a;
+      background: #0c0a08;
       color: #d4c9a0;
       overflow: hidden;
     }
@@ -34,59 +34,45 @@ export interface SpellDetailDialogData {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 14px 20px 12px;
+      padding: 8px 14px;
       flex-shrink: 0;
       border-bottom: 1px solid rgba(200, 160, 60, 0.25);
-      background: linear-gradient(180deg, rgba(28, 18, 4, 0.9) 0%, rgba(10, 8, 20, 0.9) 100%);
+      background: linear-gradient(90deg, rgba(12,10,8,.98) 0%, rgba(20,16,13,.98) 100%);
     }
 
     .dlg-title {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      font-size: 18px;
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-      color: #e8c96a;
-      text-shadow: 0 0 20px rgba(200, 160, 60, 0.5);
-    }
-
-    .dlg-title mat-icon {
-      font-size: 22px;
-      width: 22px;
-      height: 22px;
-      color: #c8a03c;
+      font-size: 14px;
+      font-family: sans-serif;
+      letter-spacing: 0.06em;
+      color: #e0d4c0;
     }
 
     .dlg-close {
-      background: none;
+      background: transparent;
       border: 1px solid rgba(200, 160, 60, 0.25);
       border-radius: 4px;
-      color: rgba(200, 160, 60, 0.6);
+      color: rgba(200, 160, 60, 0.55);
       cursor: pointer;
-      width: 32px;
-      height: 32px;
+      width: 26px;
+      height: 26px;
       display: flex;
       align-items: center;
       justify-content: center;
       padding: 0;
-      transition: all 0.18s;
+      transition: background .15s, border-color .15s, color .15s;
+      flex-shrink: 0;
 
       mat-icon {
-        font-size: 18px;
-        width: 18px;
-        height: 18px;
-        line-height: 18px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
       }
-    }
 
-    .dlg-close:hover {
-      border-color: rgba(200, 160, 60, 0.7);
-      color: #e8c96a;
-      background: rgba(200, 160, 60, 0.1);
+      &:hover {
+        background: rgba(200, 160, 60, 0.1);
+        border-color: rgba(200, 160, 60, 0.5);
+        color: #e8c96a;
+      }
     }
 
     .dlg-body {
@@ -172,10 +158,7 @@ export interface SpellDetailDialogData {
   template: `
     <div class="dlg">
       <div class="dlg-header">
-        <div class="dlg-title">
-          <mat-icon>auto_awesome</mat-icon>
-          {{ data.spellName || 'Kouzlo' }}
-        </div>
+        <div class="dlg-title">{{ data.spellName || 'Kouzlo' }}</div>
         <button class="dlg-close" (click)="close()">
           <mat-icon>close</mat-icon>
         </button>

--- a/libs/character-sheet/feature/src/lib/spells-tab/spells-tab.component.ts
+++ b/libs/character-sheet/feature/src/lib/spells-tab/spells-tab.component.ts
@@ -159,50 +159,12 @@ type SpellTypeFilter = 'kouzlo' | 'ritual';
       text-transform: uppercase; color: rgba(200,160,60,.35);
       flex-shrink: 0; margin-right: 2px;
     }
-    .chip {
-      padding: 2px 10px;
-      border: 1px solid rgba(200,160,60,.25);
-      border-radius: 12px;
-      background: none;
-      color: rgba(200,160,60,.5);
-      font-family: sans-serif;
-      font-size: 11px;
-      cursor: pointer;
-      transition: all .15s;
-      white-space: nowrap;
-      &:hover { border-color: rgba(200,160,60,.55); color: #d4c9a0; background: rgba(200,160,60,.07); }
-      &.active { background: rgba(200,160,60,.14); border-color: #c8a03c; color: #e8c96a; box-shadow: 0 0 7px rgba(200,160,60,.18); }
-    }
-    /* Level chips – same gold family as class chips */
-    .chip--level { /* inherits .chip styles – no extra override needed */ }
     /* ── Sort-mode toggle ── */
     .sort-toggle {
       margin-left: auto;
       flex-shrink: 0;
       display: flex;
-      border: 1px solid rgba(200,160,60,.22);
-      border-radius: 12px;
-      overflow: hidden;
-    }
-    .sort-toggle-btn {
-      display: flex;
-      align-items: center;
       gap: 4px;
-      padding: 2px 9px;
-      background: none;
-      border: none;
-      color: rgba(200,160,60,.4);
-      font-family: sans-serif;
-      font-size: 11px;
-      cursor: pointer;
-      transition: background .15s, color .15s;
-      white-space: nowrap;
-      &:hover { background: rgba(200,160,60,.07); color: rgba(200,160,60,.75); }
-      &.active {
-        background: rgba(200,160,60,.14);
-        color: #e8c96a;
-      }
-      & + & { border-left: 1px solid rgba(200,160,60,.22); }
     }
     /* ── Scrollable spell area ── */
     .spells-scroll {
@@ -316,17 +278,17 @@ type SpellTypeFilter = 'kouzlo' | 'ritual';
     @if (spellsService.availableClasses().length > 0) {
       <div class="filters">
         <span class="filter-label">Povolání</span>
-        <button class="chip" [class.active]="selectedClass() === null" type="button" (click)="selectedClass.set(null)">V&#353;e</button>
+        <button class="pt-filter-btn" [class.active]="selectedClass() === null" type="button" (click)="selectedClass.set(null)">V&#353;e</button>
         @for (cls of spellsService.availableClasses(); track cls) {
-          <button class="chip" [class.active]="selectedClass() === cls" type="button" (click)="toggleClass(cls)">{{ cls }}</button>
+          <button class="pt-filter-btn" [class.active]="selectedClass() === cls" type="button" (click)="toggleClass(cls)">{{ cls }}</button>
         }
         <!-- Sort-mode toggle -->
         <div class="sort-toggle" role="group" aria-label="Řazení">
-          <button class="sort-toggle-btn" [class.active]="sortMode() === 'school'" type="button"
+          <button class="pt-filter-btn" [class.active]="sortMode() === 'school'" type="button"
             (click)="sortMode.set('school')" matTooltip="Řadit podle školy magie">
             Škola
           </button>
-          <button class="sort-toggle-btn" [class.active]="sortMode() === 'level'" type="button"
+          <button class="pt-filter-btn" [class.active]="sortMode() === 'level'" type="button"
             (click)="sortMode.set('level')" matTooltip="Řadit podle úrovně kouzla">
             Úroveň
           </button>
@@ -338,15 +300,15 @@ type SpellTypeFilter = 'kouzlo' | 'ritual';
     @if (spellsService.allSpells().length > 0) {
       <div class="filters">
         <span class="filter-label">Typ</span>
-        <button class="chip" [class.active]="selectedSpellType() === null" type="button" (click)="selectedSpellType.set(null)">Vše</button>
-        <button class="chip" [class.active]="selectedSpellType() === 'kouzlo'" type="button" (click)="toggleSpellType('kouzlo')" matTooltip="Pouze kouzla (ne triky, ne rituály)">Kouzlo</button>
-        <button class="chip" [class.active]="selectedSpellType() === 'ritual'" type="button" (click)="toggleSpellType('ritual')" matTooltip="Pouze rituály">Rituál</button>
+        <button class="pt-filter-btn" [class.active]="selectedSpellType() === null" type="button" (click)="selectedSpellType.set(null)">Vše</button>
+        <button class="pt-filter-btn" [class.active]="selectedSpellType() === 'kouzlo'" type="button" (click)="toggleSpellType('kouzlo')" matTooltip="Pouze kouzla (ne triky, ne rituály)">Kouzlo</button>
+        <button class="pt-filter-btn" [class.active]="selectedSpellType() === 'ritual'" type="button" (click)="toggleSpellType('ritual')" matTooltip="Pouze rituály">Rituál</button>
           @if (availableLevels().length > 0) {
             <span class="filter-label" style="margin-left: 6px">Úroveň</span>
-            <button class="chip chip--level" [class.active]="selectedLevel() === null" type="button" (click)="selectedLevel.set(null)">Vše</button>
+            <button class="pt-filter-btn" [class.active]="selectedLevel() === null" type="button" (click)="selectedLevel.set(null)">Vše</button>
             @for (lvl of availableLevels(); track lvl) {
               <button
-                class="chip chip--level"
+                class="pt-filter-btn"
                 [class.active]="selectedLevel() === lvl"
                 type="button"
                 (click)="toggleLevel(lvl)"

--- a/libs/character-sheet/feature/src/lib/spells-tab/spells-tab.component.ts
+++ b/libs/character-sheet/feature/src/lib/spells-tab/spells-tab.component.ts
@@ -88,6 +88,7 @@ type SpellTypeFilter = 'kouzlo' | 'ritual';
   selector: 'spells-tab',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MatIcon, MatTooltip],
+  host: { '(document:keydown)': 'onDocKeydown($event)' },
   styles: `
     :host {
       display: flex;
@@ -105,39 +106,45 @@ type SpellTypeFilter = 'kouzlo' | 'ritual';
       border-bottom: 1px solid rgba(200,160,60,.22);
       background: linear-gradient(180deg, rgba(22,15,5,.97) 0%, rgba(14,10,4,.98) 100%);
     }
-    .spells-search-wrap {
-      flex: 1;
-      position: relative;
-      display: flex;
-      align-items: center;
-      .search-icon {
-        position: absolute; left: 10px;
-        font-size: 18px; width: 18px; height: 18px;
-        color: rgba(200,160,60,.45); pointer-events: none;
+
+    /* ── Wiki-style search ── */
+    .spells-search-wrap { flex: 1; position: relative; }
+    .search-row {
+      display: flex; align-items: center; gap: 9px;
+      padding: 8px 14px;
+      background: rgba(22,12,4,.97);
+      border: 1px solid rgba(200,160,60,.22);
+      border-radius: 4px; position: relative;
+      transition: border-color .15s, box-shadow .15s;
+      &:focus-within {
+        border-color: rgba(200,160,60,.52);
+        box-shadow: 0 0 0 2px rgba(200,160,60,.1);
       }
     }
+    .search-hint {
+      position: absolute; left: 43px; top: 50%; transform: translateY(-50%);
+      display: flex; align-items: center; gap: 5px;
+      font-family: sans-serif; font-size: 13px; color: rgba(200,160,60,.32);
+      pointer-events: none; user-select: none; white-space: nowrap;
+    }
+    .search-hint__kbd {
+      display: inline-flex; align-items: center; justify-content: center;
+      font-family: monospace; font-size: 11px; line-height: 1;
+      padding: 2px 6px; border: 1px solid rgba(200,160,60,.35); border-radius: 3px;
+      background: rgba(200,160,60,.08); color: rgba(200,160,60,.6);
+      box-shadow: 0 1px 0 rgba(200,160,60,.2);
+    }
+    .search-icon { color: #6a5a48; flex-shrink: 0; }
     .spells-search {
-      width: 100%;
-      background: rgba(5,3,12,.75);
-      border: 1px solid rgba(200,160,60,.28);
-      border-radius: 4px;
-      color: #d4c9a0;
-      font-family: sans-serif;
-      font-size: 13px;
-      padding: 7px 34px;
-      outline: none;
-      transition: border-color .18s, box-shadow .18s;
-      &::placeholder { color: rgba(200,160,60,.28); font-style: italic; }
-      &:focus { border-color: rgba(200,160,60,.6); box-shadow: 0 0 10px rgba(200,160,60,.12); }
+      flex: 1; background: transparent; border: none; outline: none;
+      font-family: sans-serif; font-size: 14px; color: #c8baa8; min-width: 0;
+      &::placeholder { color: #4a3a28; }
     }
     .search-clear {
-      position: absolute; right: 6px;
-      background: none; border: none; cursor: pointer;
-      color: rgba(200,160,60,.45);
-      display: flex; align-items: center;
-      padding: 2px; border-radius: 3px; transition: color .15s;
-      mat-icon { font-size: 16px; width: 16px; height: 16px; }
-      &:hover { color: #e8c96a; }
+      background: transparent; border: none; padding: 0; cursor: pointer;
+      color: #4a3a28; display: flex; align-items: center; flex-shrink: 0;
+      transition: color .12s;
+      &:hover { color: #c8a03c; }
     }
     .spells-count {
       font-family: sans-serif; font-size: 11px;
@@ -256,20 +263,33 @@ type SpellTypeFilter = 'kouzlo' | 'ritual';
     <!-- Search bar -->
     <div class="spells-header">
       <div class="spells-search-wrap">
-        <mat-icon class="search-icon">search</mat-icon>
-        <input
-          #searchInput
-          class="spells-search"
-          [value]="searchQuery()"
-          (input)="searchQuery.set($any($event.target).value)"
-          placeholder="Hledat kouzlo&#8230;"
-          autocomplete="off" spellcheck="false"
-        />
-        @if (searchQuery()) {
-          <button class="search-clear" type="button" (click)="searchQuery.set('')" matTooltip="Vymazat">
-            <mat-icon>close</mat-icon>
-          </button>
-        }
+        <div class="search-row">
+          <svg class="search-icon" viewBox="0 0 24 24" width="17" height="17" fill="currentColor" aria-hidden="true">
+            <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+          </svg>
+          <input
+            #searchInput
+            class="spells-search"
+            [value]="searchQuery()"
+            (input)="searchQuery.set($any($event.target).value)"
+            (focus)="searchFocused.set(true)"
+            (blur)="searchFocused.set(false)"
+            placeholder=""
+            autocomplete="off" spellcheck="false"
+          />
+          @if (!searchQuery() && !searchFocused()) {
+            <span class="search-hint" aria-hidden="true">
+              <kbd class="search-hint__kbd">/</kbd> pro vyhledávání
+            </span>
+          }
+          @if (searchQuery()) {
+            <button class="search-clear" type="button" (click)="clearSearch()" title="Vymazat">
+              <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor">
+                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+              </svg>
+            </button>
+          }
+        </div>
       </div>
       <span class="spells-count">{{ filteredSpells().length }}&thinsp;/&thinsp;{{ spellsService.allSpells().length }}</span>
     </div>
@@ -375,6 +395,7 @@ export class SpellsTabComponent {
   private readonly snackBar = inject(MatSnackBar);
 
   readonly searchQuery = signal('');
+  readonly searchFocused = signal(false);
   readonly selectedClass = signal<string | null>(null);
   readonly selectedSpellType = signal<SpellTypeFilter | null>(null);
   readonly selectedLevel = signal<number | null>(null);
@@ -468,6 +489,24 @@ export class SpellsTabComponent {
 
   toggleLevel(level: number): void {
     this.selectedLevel.update(cur => (cur === level ? null : level));
+  }
+
+  clearSearch(): void {
+    this.searchQuery.set('');
+    this._searchRef()?.nativeElement.focus();
+  }
+
+  /** Focus the search input when '/' is pressed outside any text field. */
+  onDocKeydown(event: KeyboardEvent): void {
+    if (event.key !== '/') return;
+    const active = document.activeElement;
+    if (
+      active instanceof HTMLInputElement ||
+      active instanceof HTMLTextAreaElement ||
+      (active as HTMLElement)?.isContentEditable
+    ) return;
+    event.preventDefault();
+    this._searchRef()?.nativeElement.focus();
   }
 
   spellTooltip(spell: JadSpell): string {

--- a/libs/character-sheet/feature/src/lib/spells-tab/spells-tab.component.ts
+++ b/libs/character-sheet/feature/src/lib/spells-tab/spells-tab.component.ts
@@ -112,7 +112,7 @@ type SpellTypeFilter = 'kouzlo' | 'ritual';
     .search-row {
       display: flex; align-items: center; gap: 9px;
       padding: 8px 14px;
-      background: rgba(22,12,4,.97);
+      background: rgba(200,160,60,.07);
       border: 1px solid rgba(200,160,60,.22);
       border-radius: 4px; position: relative;
       transition: border-color .15s, box-shadow .15s;

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.html
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.html
@@ -18,7 +18,7 @@
     <article class="chapter-article">
 
       @if (chunk.toc.length > 1) {
-        <details class="chapter-toc" open>
+        <details class="chapter-toc" [attr.open]="tocOpen() ? '' : null" (toggle)="onTocToggle($event)">
           <summary class="chapter-toc__summary">
             <span class="material-symbols-outlined chapter-toc__icon">toc</span>
             <span class="chapter-toc__title">Obsah kapitoly</span>

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.scss
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.scss
@@ -482,7 +482,8 @@
    Tables — DnD dark fantasy style with crimson/gold accents
 ══════════════════════════════════════════════════════════════ */
 .wiki-body table {
-  width: 100%;
+  width: fit-content;   /* only as wide as the content needs */
+  max-width: 100%;      /* never overflow the article container */
   border-collapse: separate;
   border-spacing: 0;
   margin: 1.8em 0;

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.scss
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.scss
@@ -126,7 +126,7 @@
 /* ── Chapter article ── */
 .chapter-article {
   padding: 32px 40px 24px;
-  max-width: 860px;
+  max-width: 1200px;
   margin: 0 auto;
 }
 .chapter-article__header {

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.ts
@@ -16,6 +16,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { WikiBook, WikiChapter } from './wiki-catalog.const';
 import { WikiService } from './wiki.service';
 import { MatIcon } from '@angular/material/icon';
+import { LocalStorageService, WIKI_TOC_OPEN_KEY } from '@dn-d-servant/util';
 
 export interface TocEntry {
   level: number; // 2–5
@@ -117,6 +118,7 @@ export class WikiContentComponent implements AfterViewInit, OnDestroy {
   private readonly wikiService = inject(WikiService);
   private readonly sanitizer = inject(DomSanitizer);
   private readonly snackBar = inject(MatSnackBar);
+  private readonly ls = inject(LocalStorageService);
 
   readonly scrollContainer = viewChild.required<ElementRef<HTMLElement>>('scrollContainer');
   readonly sentinel = viewChild<ElementRef<HTMLElement>>('sentinel');
@@ -127,6 +129,12 @@ export class WikiContentComponent implements AfterViewInit, OnDestroy {
   protected readonly currentBook = signal<WikiBook | null>(null);
   /** Search query for filtering chapter TOC entries. */
   readonly tocFilter = signal('');
+  /**
+   * Whether the "Obsah kapitoly" accordion is expanded.
+   * Persisted to localStorage so it survives page reloads.
+   * Defaults to `true` (open) when no saved value exists.
+   */
+  readonly tocOpen = signal<boolean>(this.ls.getDataSync<boolean>(WIKI_TOC_OPEN_KEY) ?? true);
   private nextIndex = 0;
 
   /** Per-chunk filtered + highlighted TOC entries, recomputed on filter change. */
@@ -340,6 +348,13 @@ export class WikiContentComponent implements AfterViewInit, OnDestroy {
     } else {
       this.pendingScrollSlug.set(slug);
     }
+  }
+
+  /** Persist the "Obsah kapitoly" open/closed state to localStorage. */
+  onTocToggle(event: Event): void {
+    const open = (event.target as HTMLDetailsElement).open;
+    this.tocOpen.set(open);
+    this.ls.setDataSync(WIKI_TOC_OPEN_KEY, open);
   }
 
   /** Handle clicks on heading anchor buttons via event delegation. */

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-content.component.ts
@@ -104,8 +104,11 @@ function extractToc(html: string): TocEntry[] {
 }
 
 const CHAPTERS_PER_LOAD = 2;
-/** Gap (px) kept above the heading so it isn't flush against the container edge. */
-const SCROLL_HEADING_OFFSET = 24;
+/**
+ * Gap kept above a heading after scroll-to.
+ * 70 px accounts for the app mat-toolbar (≈ 64 px) + a small breathing gap.
+ */
+const SCROLL_HEADING_OFFSET = 70;
 
 @Component({
   selector: 'wiki-content',

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
@@ -72,7 +72,6 @@ interface SearchResult {
             @for (book of catalog; track book.id) {
               <div class="book" [class.book--active]="expandedBook() === book.id">
                 <button class="book__header" (click)="toggleBook(book.id)">
-                  <mat-icon class="book__icon">{{ book.icon }}</mat-icon>
                   <span class="book__label">{{ book.label }}</span>
                   <mat-icon class="book__chevron">
                     {{ expandedBook() === book.id ? 'expand_less' : 'expand_more' }}
@@ -294,12 +293,6 @@ interface SearchResult {
       background: rgba(200, 100, 30, 0.08);
     }
 
-    .book__icon {
-      font-size: 18px;
-      width: 18px;
-      height: 18px;
-      flex-shrink: 0;
-    }
 
     .book__label {
       flex: 1;

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
@@ -10,7 +10,6 @@ import {
   model,
   output,
   signal,
-  untracked,
 } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catalog.const';
@@ -457,19 +456,17 @@ export class WikiSidebarComponent {
 
   constructor() {
     // When activeBookId changes (e.g. from a search result), expand the correct
-    // book in the sidebar and scroll the active chapter item into view.
+    // book accordion and queue a scroll to the active chapter item.
+    // NOTE: we deliberately do NOT touch `collapsed` here — opening/closing the
+    // sidebar is the parent's responsibility (wiki-tab). Forcing collapsed=false
+    // here would race with wiki-tab's sidebarCollapsed.set(true) and reopen the
+    // sidebar even after the user (or code) just closed it.
     effect(() => {
       const bookId = this.activeBookId();
       if (!bookId) return;
 
       this.expandedBook.set(bookId);
 
-      // Use untracked so `collapsed` is NOT a reactive dependency of this effect.
-      // Without this, every user click to collapse re-triggers the effect which
-      // immediately un-collapses the sidebar again.
-      if (untracked(() => this.collapsed())) {
-        this.collapsed.set(false);
-      }
 
       this.needsScroll.set(true);
     });

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
@@ -10,6 +10,7 @@ import {
   model,
   output,
   signal,
+  untracked,
 } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catalog.const';
@@ -28,27 +29,11 @@ interface SearchResult {
   imports: [MatIcon],
   template: `
     <div class="sidebar" [class.sidebar--collapsed]="collapsed()">
-      <!-- Header row: toggle + title -->
-      <div class="sidebar__header">
-        <button
-          class="sidebar__toggle"
-          (click)="collapsed.set(!collapsed())"
-          [title]="collapsed() ? 'Rozbalit nabídku' : 'Sbalit nabídku'"
-          aria-label="Přepnout postranní panel"
-        >
-          <mat-icon>{{ collapsed() ? 'menu_open' : 'menu' }}</mat-icon>
-        </button>
-        @if (!collapsed()) {
-          <h3 class="sidebar__heading">J&amp;D Wiki</h3>
-        }
-      </div>
-
       @if (!collapsed()) {
         <!-- Search bar -->
         <div class="sidebar__search-wrap">
           <span class="material-symbols-outlined sidebar__search-icon">search</span>
           <input
-            #searchInput
             class="sidebar__search"
             type="search"
             placeholder="Hledat v obsahu…"
@@ -147,55 +132,7 @@ interface SearchResult {
       transform: translateX(-100%);
     }
 
-    /* ── Header row ── */
-    .sidebar__header {
-      display: flex;
-      align-items: center;
-      flex-shrink: 0;
-      border-bottom: 1px solid rgba(200, 160, 60, 0.15);
-    }
-
-    /* ── Toggle button ── */
-    .sidebar__toggle {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 44px;
-      height: 44px;
-      flex-shrink: 0;
-      background: transparent;
-      border: none;
-      color: #8a7a68;
-      cursor: pointer;
-      transition: color 0.15s, background 0.15s;
-
-      &:hover {
-        color: #c8a03c;
-        background: rgba(200, 160, 60, 0.06);
-      }
-
-      mat-icon {
-        font-size: 20px;
-        width: 20px;
-        height: 20px;
-      }
-    }
-
-    .sidebar__heading {
-      font-family: sans-serif;
-      font-size: 13px;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
-      color: rgba(200, 160, 60, 0.5);
-      padding: 0 16px 0 4px;
-      margin: 0;
-      flex: 1;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    /* ── Search bar ── */
+    /* ── Search bar — first visible element ── */
     .sidebar__search-wrap {
       display: flex;
       align-items: center;
@@ -430,6 +367,8 @@ export class WikiSidebarComponent {
   private readonly elRef = inject(ElementRef<HTMLElement>);
   /** Set to true when the sidebar needs to scroll to the active chapter after the next render. */
   private readonly needsScroll = signal(false);
+  /** Tracks the previous collapsed state so we can detect open transitions. */
+  private prevCollapsed = true;
 
   /** Flat list of chapters matching the current filter query. */
   readonly searchResults = computed((): SearchResult[] => {
@@ -455,31 +394,35 @@ export class WikiSidebarComponent {
   });
 
   constructor() {
-    // When activeBookId changes (e.g. from a search result), expand the correct
-    // book accordion and queue a scroll to the active chapter item.
-    // NOTE: we deliberately do NOT touch `collapsed` here — opening/closing the
-    // sidebar is the parent's responsibility (wiki-tab). Forcing collapsed=false
-    // here would race with wiki-tab's sidebarCollapsed.set(true) and reopen the
-    // sidebar even after the user (or code) just closed it.
+    // When activeBookId changes expand the correct book accordion and queue scroll.
     effect(() => {
       const bookId = this.activeBookId();
       if (!bookId) return;
-
       this.expandedBook.set(bookId);
-
-
       this.needsScroll.set(true);
     });
 
-    // After Angular renders (and the chapter list is in the DOM), scroll to the
-    // active chapter. Retries automatically on every render cycle until the element
-    // appears. Uses afterRenderEffect instead of setTimeout to stay zone-less safe.
+    // After Angular renders, scroll to the active chapter item.
     afterRenderEffect(() => {
       if (!this.needsScroll()) return;
       const activeEl = this.elRef.nativeElement.querySelector('.chapter--active') as HTMLElement | null;
-      if (!activeEl) return; // not in DOM yet — next render cycle will retry
+      if (!activeEl) return;
       this.needsScroll.set(false);
       activeEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    });
+
+    // Auto-focus the search input whenever the sidebar transitions from closed → open.
+    // afterRenderEffect guarantees the input is in the DOM before we try to focus.
+    afterRenderEffect(() => {
+      const isCollapsed = this.collapsed();
+      untracked(() => {
+        const wasCollapsed = this.prevCollapsed;
+        this.prevCollapsed = isCollapsed;
+        if (!isCollapsed && wasCollapsed) {
+          const input = this.elRef.nativeElement.querySelector('.sidebar__search') as HTMLInputElement | null;
+          input?.focus();
+        }
+      });
     });
   }
 

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  computed,
   effect,
   inject,
   input,
@@ -13,6 +14,14 @@ import {
 } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catalog.const';
+import { escapeHtml, highlightMatch } from './wiki-utils';
+
+interface SearchResult {
+  book: WikiBook;
+  chapter: WikiChapter;
+  bookHtml: string;
+  chapterHtml: string;
+}
 
 @Component({
   selector: 'wiki-sidebar',
@@ -26,6 +35,7 @@ import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catal
           class="sidebar__toggle"
           (click)="collapsed.set(!collapsed())"
           [title]="collapsed() ? 'Rozbalit nabídku' : 'Sbalit nabídku'"
+          aria-label="Přepnout postranní panel"
         >
           <mat-icon>{{ collapsed() ? 'menu_open' : 'menu' }}</mat-icon>
         </button>
@@ -35,60 +45,117 @@ import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catal
       </div>
 
       @if (!collapsed()) {
+        <!-- Search bar -->
+        <div class="sidebar__search-wrap">
+          <span class="material-symbols-outlined sidebar__search-icon">search</span>
+          <input
+            #searchInput
+            class="sidebar__search"
+            type="search"
+            placeholder="Hledat v obsahu…"
+            [value]="filter()"
+            (input)="filter.set($any($event.target).value)"
+            aria-label="Hledat ve wiki"
+          />
+          @if (filter()) {
+            <button class="sidebar__search-clear" (click)="filter.set('')" aria-label="Vymazat hledání">
+              <mat-icon>close</mat-icon>
+            </button>
+          }
+        </div>
+
         <div class="sidebar__content">
+          @if (filter()) {
+            <!-- Flat search results -->
+            @if (searchResults().length === 0) {
+              <div class="sidebar__no-results">Žádné výsledky</div>
+            }
+            @for (result of searchResults(); track result.chapter.id) {
+              <div
+                class="search-result"
+                [class.search-result--active]="isActive(result.book, result.chapter)"
+                (click)="selectChapter(result.book, result.chapter)"
+                role="button"
+                tabindex="0"
+                (keydown.enter)="selectChapter(result.book, result.chapter)"
+              >
+                <div class="search-result__book" [innerHTML]="result.bookHtml"></div>
+                <div class="search-result__chapter" [innerHTML]="result.chapterHtml"></div>
+              </div>
+            }
+          } @else {
+            <!-- Normal book accordion -->
+            @for (book of catalog; track book.id) {
+              <div class="book" [class.book--active]="expandedBook() === book.id">
+                <button class="book__header" (click)="toggleBook(book.id)">
+                  <mat-icon class="book__icon">{{ book.icon }}</mat-icon>
+                  <span class="book__label">{{ book.label }}</span>
+                  <mat-icon class="book__chevron">
+                    {{ expandedBook() === book.id ? 'expand_less' : 'expand_more' }}
+                  </mat-icon>
+                </button>
 
-          @for (book of catalog; track book.id) {
-            <div class="book" [class.book--active]="expandedBook() === book.id">
-              <button class="book__header" (click)="toggleBook(book.id)">
-                <mat-icon class="book__icon">{{ book.icon }}</mat-icon>
-                <span class="book__label">{{ book.label }}</span>
-                <mat-icon class="book__chevron">
-                  {{ expandedBook() === book.id ? 'expand_less' : 'expand_more' }}
-                </mat-icon>
-              </button>
-
-              @if (expandedBook() === book.id) {
-                <ul class="book__chapters">
-                  @for (chapter of book.chapters; track chapter.id) {
-                    <li class="chapter" [class.chapter--active]="isActive(book, chapter)" (click)="selectChapter(book, chapter)">
-                      {{ chapter.label }}
-                    </li>
-                  }
-                </ul>
-              }
-            </div>
+                @if (expandedBook() === book.id) {
+                  <ul class="book__chapters">
+                    @for (chapter of book.chapters; track chapter.id) {
+                      <li
+                        class="chapter"
+                        [class.chapter--active]="isActive(book, chapter)"
+                        (click)="selectChapter(book, chapter)"
+                      >
+                        {{ chapter.label }}
+                      </li>
+                    }
+                  </ul>
+                }
+              </div>
+            }
           }
         </div>
       }
     </div>
   `,
   styles: `
+    /* ── Host: absolutely positioned so it never participates in the flex layout
+       and collapsing/expanding never causes a layout reflow of the content. ── */
     :host {
-      display: flex;
+      position: absolute;
+      left: 0;
+      top: 0;
       height: 100%;
+      z-index: 20;
+      /* pointer-events only on the sidebar element itself */
+      pointer-events: none;
     }
 
     .sidebar {
+      pointer-events: all;
       width: 280px;
-      min-width: 280px;
       height: 100%;
       display: flex;
       flex-direction: column;
       background: linear-gradient(180deg, rgba(18, 10, 4, 0.98) 0%, rgba(12, 7, 2, 0.99) 100%);
       border-right: 1px solid rgba(200, 160, 60, 0.2);
-      transition:
-        width 0.2s ease,
-        min-width 0.2s ease;
+      /* GPU-composited transform — zero layout reflow */
+      transform: translateX(0);
+      transition: transform 0.22s ease;
       overflow: hidden;
-      position: relative;
+      box-shadow: 4px 0 24px rgba(0, 0, 0, 0.5);
     }
 
+    /* Desktop collapsed: slide left so only the 44 px toggle strip is visible */
     .sidebar--collapsed {
-      width: 44px;
-      min-width: 44px;
+      transform: translateX(-236px); /* 280 - 44 = 236 */
     }
 
-    /* ── Header row (toggle + title) ── */
+    /* Mobile / tablet: fully hide the sidebar when collapsed */
+    @media (max-width: 1023px) {
+      .sidebar--collapsed {
+        transform: translateX(-100%);
+      }
+    }
+
+    /* ── Header row ── */
     .sidebar__header {
       display: flex;
       align-items: center;
@@ -108,9 +175,7 @@ import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catal
       border: none;
       color: #8a7a68;
       cursor: pointer;
-      transition:
-        color 0.15s,
-        background 0.15s;
+      transition: color 0.15s, background 0.15s;
 
       &:hover {
         color: #c8a03c;
@@ -121,25 +186,6 @@ import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catal
         font-size: 20px;
         width: 20px;
         height: 20px;
-      }
-    }
-
-    /* ── Scrollable content ── */
-    .sidebar__content {
-      flex: 1;
-      overflow-y: auto;
-      overflow-x: hidden;
-      padding: 0 0 40px;
-
-      &::-webkit-scrollbar {
-        width: 4px;
-      }
-      &::-webkit-scrollbar-track {
-        background: transparent;
-      }
-      &::-webkit-scrollbar-thumb {
-        background: rgba(200, 160, 60, 0.25);
-        border-radius: 2px;
       }
     }
 
@@ -157,6 +203,142 @@ import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catal
       text-overflow: ellipsis;
     }
 
+    /* ── Search bar ── */
+    .sidebar__search-wrap {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin: 8px 10px;
+      padding: 4px 8px;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(200, 160, 60, 0.18);
+      border-radius: 6px;
+      flex-shrink: 0;
+
+      &:focus-within {
+        border-color: rgba(200, 160, 60, 0.45);
+        background: rgba(255, 255, 255, 0.06);
+      }
+    }
+
+    .sidebar__search-icon {
+      font-size: 16px;
+      color: rgba(200, 160, 60, 0.4);
+      flex-shrink: 0;
+      font-family: 'Material Symbols Outlined', sans-serif;
+    }
+
+    .sidebar__search {
+      flex: 1;
+      background: transparent;
+      border: none;
+      outline: none;
+      color: #d4b880;
+      font-size: 12px;
+      min-width: 0;
+
+      &::placeholder {
+        color: rgba(200, 160, 60, 0.3);
+      }
+
+      /* Hide browser's native search-clear button */
+      &::-webkit-search-cancel-button { display: none; }
+    }
+
+    .sidebar__search-clear {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      flex-shrink: 0;
+      background: transparent;
+      border: none;
+      color: rgba(200, 160, 60, 0.4);
+      cursor: pointer;
+      padding: 0;
+      border-radius: 3px;
+
+      &:hover { color: #c8a03c; }
+
+      mat-icon {
+        font-size: 14px;
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    /* ── Scrollable content ── */
+    .sidebar__content {
+      flex: 1;
+      overflow-y: auto;
+      overflow-x: hidden;
+      padding: 0 0 40px;
+
+      &::-webkit-scrollbar { width: 4px; }
+      &::-webkit-scrollbar-track { background: transparent; }
+      &::-webkit-scrollbar-thumb {
+        background: rgba(200, 160, 60, 0.25);
+        border-radius: 2px;
+      }
+    }
+
+    .sidebar__no-results {
+      padding: 16px;
+      font-size: 11px;
+      color: rgba(200, 160, 60, 0.35);
+      text-align: center;
+      font-family: sans-serif;
+    }
+
+    /* ── Search results ── */
+    .search-result {
+      padding: 8px 14px;
+      border-bottom: 1px solid rgba(200, 160, 60, 0.06);
+      cursor: pointer;
+      transition: background 0.12s;
+
+      &:hover { background: rgba(200, 160, 60, 0.06); }
+    }
+
+    .search-result--active {
+      background: rgba(180, 80, 20, 0.15) !important;
+      border-left: 2px solid rgba(210, 120, 40, 0.6);
+      padding-left: 12px;
+    }
+
+    .search-result__book {
+      font-size: 9.5px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgba(200, 160, 60, 0.4);
+      font-family: sans-serif;
+      margin-bottom: 2px;
+
+      ::ng-deep mark.hl {
+        background: rgba(200, 160, 60, 0.35);
+        color: #f0c080;
+        border-radius: 2px;
+        padding: 0 1px;
+      }
+    }
+
+    .search-result__chapter {
+      font-size: 11px;
+      color: #9a8878;
+      font-family: sans-serif;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      ::ng-deep mark.hl {
+        background: rgba(200, 160, 60, 0.35);
+        color: #f0c080;
+        border-radius: 2px;
+        padding: 0 1px;
+      }
+    }
+
     /* ── Book accordion ── */
     .book__header {
       display: flex;
@@ -170,9 +352,7 @@ import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catal
       cursor: pointer;
       gap: 8px;
       text-align: left;
-      transition:
-        color 0.15s,
-        background 0.15s;
+      transition: color 0.15s, background 0.15s;
 
       &:hover {
         color: #c8a03c;
@@ -226,9 +406,7 @@ import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catal
       color: #5e5448;
       border-bottom: 1px solid rgba(200, 160, 60, 0.04);
       cursor: pointer;
-      transition:
-        color 0.12s,
-        background 0.12s;
+      transition: color 0.12s, background 0.12s;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -255,31 +433,53 @@ export class WikiSidebarComponent {
 
   readonly catalog = WIKI_CATALOG;
   readonly expandedBook = signal<string | null>(null);
+  readonly filter = signal('');
 
   private readonly elRef = inject(ElementRef<HTMLElement>);
   /** Set to true when the sidebar needs to scroll to the active chapter after the next render. */
   private readonly needsScroll = signal(false);
 
+  /** Flat list of chapters matching the current filter query. */
+  readonly searchResults = computed((): SearchResult[] => {
+    const q = this.filter();
+    if (!q.trim()) return [];
+    const results: SearchResult[] = [];
+    for (const book of WIKI_CATALOG) {
+      const bookHtmlBase = highlightMatch(book.label, q);
+      for (const chapter of book.chapters) {
+        const chapterHtml = highlightMatch(chapter.label, q);
+        // Include if chapter label matches, or if book label matches
+        if (chapterHtml !== null || bookHtmlBase !== null) {
+          results.push({
+            book,
+            chapter,
+            bookHtml: bookHtmlBase ?? escapeHtml(book.label),
+            chapterHtml: chapterHtml ?? escapeHtml(chapter.label),
+          });
+        }
+      }
+    }
+    return results;
+  });
+
   constructor() {
     // When activeBookId changes (e.g. from a search result), expand the correct
     // book in the sidebar and scroll the active chapter item into view.
-    effect(
-      () => {
-        const bookId = this.activeBookId();
-        if (!bookId) return;
+    effect(() => {
+      const bookId = this.activeBookId();
+      if (!bookId) return;
 
-        this.expandedBook.set(bookId);
+      this.expandedBook.set(bookId);
 
-        // Use untracked so `collapsed` is NOT a reactive dependency of this effect.
-        // Without this, every user click to collapse re-triggers the effect which
-        // immediately un-collapses the sidebar again.
-        if (untracked(() => this.collapsed())) {
-          this.collapsed.set(false);
-        }
+      // Use untracked so `collapsed` is NOT a reactive dependency of this effect.
+      // Without this, every user click to collapse re-triggers the effect which
+      // immediately un-collapses the sidebar again.
+      if (untracked(() => this.collapsed())) {
+        this.collapsed.set(false);
+      }
 
-        this.needsScroll.set(true);
-      },
-    );
+      this.needsScroll.set(true);
+    });
 
     // After Angular renders (and the chapter list is in the DOM), scroll to the
     // active chapter. Retries automatically on every render cycle until the element
@@ -298,6 +498,7 @@ export class WikiSidebarComponent {
   }
 
   selectChapter(book: WikiBook, chapter: WikiChapter): void {
+    this.filter.set('');
     this.chapterSelect.emit({ book, chapter });
   }
 

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-sidebar.component.ts
@@ -143,16 +143,9 @@ interface SearchResult {
       box-shadow: 4px 0 24px rgba(0, 0, 0, 0.5);
     }
 
-    /* Desktop collapsed: slide left so only the 44 px toggle strip is visible */
+    /* Fully hidden on every viewport when collapsed */
     .sidebar--collapsed {
-      transform: translateX(-236px); /* 280 - 44 = 236 */
-    }
-
-    /* Mobile / tablet: fully hide the sidebar when collapsed */
-    @media (max-width: 1023px) {
-      .sidebar--collapsed {
-        transform: translateX(-100%);
-      }
+      transform: translateX(-100%);
     }
 
     /* ── Header row ── */

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-tab.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-tab.component.ts
@@ -5,27 +5,42 @@ import { WikiSearchComponent } from './wiki-search.component';
 import { WikiBook, WikiChapter, WikiSelection, WIKI_CATALOG } from './wiki-catalog.const';
 import { LocalStorageService, WIKI_LAST_POSITION_KEY } from '@dn-d-servant/util';
 import { slugify } from './wiki-utils';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
   selector: 'wiki-tab',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [WikiSidebarComponent, WikiContentComponent, WikiSearchComponent],
+  imports: [WikiSidebarComponent, WikiContentComponent, WikiSearchComponent, MatIcon],
   template: `
     <div class="wiki-root">
       <!-- Toolbar with search -->
       <div class="wiki-toolbar">
+        <!-- Mobile/tablet sidebar toggle -->
+        <button
+          class="wiki-toolbar__sidebar-btn"
+          (click)="sidebarCollapsed.set(!sidebarCollapsed())"
+          [title]="sidebarCollapsed() ? 'Otevřít navigaci' : 'Zavřít navigaci'"
+          aria-label="Přepnout postranní panel"
+        >
+          <mat-icon>{{ sidebarCollapsed() ? 'menu' : 'menu_open' }}</mat-icon>
+        </button>
         <wiki-search (chapterSelect)="onChapterSelect($event)" />
       </div>
 
-      <!-- Main layout: sidebar + content -->
+      <!-- Main layout: sidebar (absolute overlay) + content (always full-width) -->
       <div class="wiki-layout">
+        <!-- Backdrop: visible on mobile/tablet when sidebar is open -->
+        @if (!sidebarCollapsed()) {
+          <div class="wiki-backdrop" (click)="sidebarCollapsed.set(true)" aria-hidden="true"></div>
+        }
+
         <wiki-sidebar
           [(collapsed)]="sidebarCollapsed"
           [activeBookId]="activeBook()?.id ?? null"
           [activeChapterId]="activeChapter()?.id ?? null"
           (chapterSelect)="onChapterSelect($event)"
         />
-        <wiki-content #contentRef />
+        <wiki-content #contentRef class="wiki-content-host" />
       </div>
     </div>
   `,
@@ -48,12 +63,44 @@ import { slugify } from './wiki-utils';
     .wiki-toolbar {
       display: flex;
       align-items: center;
-      justify-content: center;
       padding: 8px 16px;
       border-bottom: 1px solid rgba(200, 160, 60, 0.12);
       background: rgba(12, 7, 2, 0.98);
       flex-shrink: 0;
-      gap: 12px;
+      gap: 8px;
+    }
+
+    /* Mobile toggle — always visible in the toolbar */
+    .wiki-toolbar__sidebar-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      flex-shrink: 0;
+      background: transparent;
+      border: 1px solid rgba(200, 160, 60, 0.2);
+      border-radius: 6px;
+      color: #8a7a68;
+      cursor: pointer;
+      transition: color 0.15s, background 0.15s, border-color 0.15s;
+
+      &:hover {
+        color: #c8a03c;
+        background: rgba(200, 160, 60, 0.08);
+        border-color: rgba(200, 160, 60, 0.4);
+      }
+
+      mat-icon {
+        font-size: 20px;
+        width: 20px;
+        height: 20px;
+      }
+    }
+
+    /* On desktop keep the toolbar search centered */
+    wiki-search {
+      flex: 1;
     }
 
     /* ── Sidebar + content row ── */
@@ -61,6 +108,29 @@ import { slugify } from './wiki-utils';
       display: flex;
       flex: 1;
       overflow: hidden;
+      position: relative; /* anchor for the absolutely-positioned sidebar */
+    }
+
+    /* Content always takes the full width — sidebar floats over it */
+    .wiki-content-host {
+      flex: 1;
+      min-width: 0;
+    }
+
+    /* ── Backdrop (mobile/tablet only) ── */
+    .wiki-backdrop {
+      display: none; /* hidden on desktop */
+      position: absolute;
+      inset: 0;
+      z-index: 15; /* below sidebar (z-index: 20) but above content */
+      background: rgba(0, 0, 0, 0.55);
+      cursor: pointer;
+    }
+
+    @media (max-width: 1023px) {
+      .wiki-backdrop {
+        display: block;
+      }
     }
   `,
 })
@@ -69,7 +139,10 @@ export class WikiTabComponent implements AfterViewInit {
 
   readonly contentRef = viewChild.required<WikiContentComponent>('contentRef');
 
-  readonly sidebarCollapsed = signal(false);
+  /** Collapsed by default on mobile/tablet (<= 1023 px), expanded on desktop. */
+  readonly sidebarCollapsed = signal(
+    typeof window !== 'undefined' && window.innerWidth <= 1023,
+  );
   readonly activeBook = signal<WikiBook | null>(null);
   readonly activeChapter = signal<WikiChapter | null>(null);
 
@@ -83,6 +156,11 @@ export class WikiTabComponent implements AfterViewInit {
   onChapterSelect(selection: WikiSelection): void {
     this.activeBook.set(selection.book);
     this.activeChapter.set(selection.chapter);
+
+    // Close sidebar automatically on mobile/tablet after selecting a chapter
+    if (typeof window !== 'undefined' && window.innerWidth <= 1023) {
+      this.sidebarCollapsed.set(true);
+    }
 
     this.ls.setDataSync(WIKI_LAST_POSITION_KEY, {
       bookId: selection.book.id,

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-tab.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-tab.component.ts
@@ -15,21 +15,28 @@ import { MatIcon } from '@angular/material/icon';
     <div class="wiki-root">
       <!-- Toolbar with search -->
       <div class="wiki-toolbar">
-        <!-- Mobile/tablet sidebar toggle -->
-        <button
-          class="wiki-toolbar__sidebar-btn"
-          (click)="sidebarCollapsed.set(!sidebarCollapsed())"
-          [title]="sidebarCollapsed() ? 'Otevřít navigaci' : 'Zavřít navigaci'"
-          aria-label="Přepnout postranní panel"
-        >
-          <mat-icon>{{ sidebarCollapsed() ? 'menu' : 'menu_open' }}</mat-icon>
-        </button>
-        <wiki-search (chapterSelect)="onChapterSelect($event)" />
+        <!-- Sidebar toggle — left slot -->
+        <div class="wiki-toolbar__left">
+          <button
+            class="wiki-toolbar__sidebar-btn"
+            (click)="sidebarCollapsed.set(!sidebarCollapsed())"
+            [title]="sidebarCollapsed() ? 'Otevřít navigaci' : 'Zavřít navigaci'"
+            aria-label="Přepnout postranní panel"
+          >
+            <mat-icon>{{ sidebarCollapsed() ? 'menu' : 'menu_open' }}</mat-icon>
+          </button>
+        </div>
+
+        <!-- Search — centre slot -->
+        <wiki-search class="wiki-toolbar__search" (chapterSelect)="onChapterSelect($event)" />
+
+        <!-- Right spacer — mirrors left slot so search stays centred -->
+        <div class="wiki-toolbar__right"></div>
       </div>
 
       <!-- Main layout: sidebar (absolute overlay) + content (always full-width) -->
       <div class="wiki-layout">
-        <!-- Backdrop: visible on mobile/tablet when sidebar is open -->
+        <!-- Backdrop: always shown when sidebar is open, closes it on click -->
         @if (!sidebarCollapsed()) {
           <div class="wiki-backdrop" (click)="sidebarCollapsed.set(true)" aria-hidden="true"></div>
         }
@@ -60,22 +67,31 @@ import { MatIcon } from '@angular/material/icon';
       overflow: hidden;
     }
 
-    /* ── Toolbar ── */
+    /* ── Toolbar — 3-column layout so search is always centred ── */
     .wiki-toolbar {
       display: flex;
       align-items: center;
-      justify-content: center;
-      padding: 8px 16px;
+      padding: 6px 12px;
       border-bottom: 1px solid rgba(200, 160, 60, 0.12);
       background: rgba(12, 7, 2, 0.98);
       flex-shrink: 0;
-      position: relative; /* anchor for absolute toggle button */
+      gap: 8px;
     }
 
-    /* Toggle button — absolutely pinned to left so search stays centred */
+    /* Left and right slots take equal space → search is perfectly centred */
+    .wiki-toolbar__left,
+    .wiki-toolbar__right {
+      flex: 1;
+      display: flex;
+      align-items: center;
+    }
+
+    .wiki-toolbar__right {
+      justify-content: flex-end;
+    }
+
+    /* Toggle button */
     .wiki-toolbar__sidebar-btn {
-      position: absolute;
-      left: 16px;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -102,10 +118,10 @@ import { MatIcon } from '@angular/material/icon';
       }
     }
 
-    /* Search is the only flex child — it naturally centres */
-    wiki-search {
-      max-width: 560px;
-      width: 100%;
+    /* Centre slot — search stretches up to 560 px but never overflows */
+    .wiki-toolbar__search {
+      flex: 0 1 560px;
+      min-width: 0;
     }
 
     /* ── Sidebar + content row ── */
@@ -122,20 +138,13 @@ import { MatIcon } from '@angular/material/icon';
       min-width: 0;
     }
 
-    /* ── Backdrop (mobile/tablet only) ── */
+    /* ── Backdrop — always rendered when sidebar is open ── */
     .wiki-backdrop {
-      display: none; /* hidden on desktop */
       position: absolute;
       inset: 0;
       z-index: 15; /* below sidebar (z-index: 20) but above content */
       background: rgba(0, 0, 0, 0.55);
       cursor: pointer;
-    }
-
-    @media (max-width: 1023px) {
-      .wiki-backdrop {
-        display: block;
-      }
     }
   `,
 })
@@ -163,10 +172,9 @@ export class WikiTabComponent implements AfterViewInit {
     this.activeBook.set(selection.book);
     this.activeChapter.set(selection.chapter);
 
-    // Close sidebar automatically on mobile/tablet after selecting a chapter
-    if (typeof window !== 'undefined' && window.innerWidth <= 1023) {
-      this.sidebarCollapsed.set(true);
-    }
+    // Always close the sidebar after any chapter selection so the content is
+    // immediately visible (on desktop the user can reopen with the toolbar button).
+    this.sidebarCollapsed.set(true);
 
     this.ls.setDataSync(WIKI_LAST_POSITION_KEY, {
       bookId: selection.book.id,
@@ -210,16 +218,18 @@ export class WikiTabComponent implements AfterViewInit {
 
   /**
    * Restore the last viewed wiki position from LocalStorage.
-   * Used on startup when no URL fragment is present.
+   * Falls back to 'Jeskyně a draci – Úvod' when no position has been saved yet.
    */
   private restoreLastPosition(): void {
     const saved = this.ls.getDataSync<{ bookId: string; chapterId: string }>(WIKI_LAST_POSITION_KEY);
-    if (!saved?.bookId || !saved?.chapterId) return;
 
-    const book = WIKI_CATALOG.find(b => b.id === saved.bookId);
+    const bookId    = saved?.bookId    ?? 'jeskyne-a-draci';
+    const chapterId = saved?.chapterId ?? '0-uvod.md';
+
+    const book = WIKI_CATALOG.find(b => b.id === bookId);
     if (!book) return;
 
-    const chapter = book.chapters.find(c => c.id === saved.chapterId);
+    const chapter = book.chapters.find(c => c.id === chapterId);
     if (!chapter) return;
 
     this.activeBook.set(book);

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-tab.component.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-tab.component.ts
@@ -35,7 +35,8 @@ import { MatIcon } from '@angular/material/icon';
         }
 
         <wiki-sidebar
-          [(collapsed)]="sidebarCollapsed"
+          [collapsed]="sidebarCollapsed()"
+          (collapsedChange)="sidebarCollapsed.set($event)"
           [activeBookId]="activeBook()?.id ?? null"
           [activeChapterId]="activeChapter()?.id ?? null"
           (chapterSelect)="onChapterSelect($event)"
@@ -63,15 +64,18 @@ import { MatIcon } from '@angular/material/icon';
     .wiki-toolbar {
       display: flex;
       align-items: center;
+      justify-content: center;
       padding: 8px 16px;
       border-bottom: 1px solid rgba(200, 160, 60, 0.12);
       background: rgba(12, 7, 2, 0.98);
       flex-shrink: 0;
-      gap: 8px;
+      position: relative; /* anchor for absolute toggle button */
     }
 
-    /* Mobile toggle — always visible in the toolbar */
+    /* Toggle button — absolutely pinned to left so search stays centred */
     .wiki-toolbar__sidebar-btn {
+      position: absolute;
+      left: 16px;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -98,9 +102,10 @@ import { MatIcon } from '@angular/material/icon';
       }
     }
 
-    /* On desktop keep the toolbar search centered */
+    /* Search is the only flex child — it naturally centres */
     wiki-search {
-      flex: 1;
+      max-width: 560px;
+      width: 100%;
     }
 
     /* ── Sidebar + content row ── */
@@ -139,8 +144,9 @@ export class WikiTabComponent implements AfterViewInit {
 
   readonly contentRef = viewChild.required<WikiContentComponent>('contentRef');
 
-  /** Collapsed by default on mobile/tablet (<= 1023 px), expanded on desktop. */
-  readonly sidebarCollapsed = signal(
+  /** Collapsed by default on mobile/tablet (<= 1023 px), expanded on desktop.
+   *  Not readonly — the child's [(collapsed)] two-way binding calls .set() on this signal. */
+  sidebarCollapsed = signal(
     typeof window !== 'undefined' && window.innerWidth <= 1023,
   );
   readonly activeBook = signal<WikiBook | null>(null);

--- a/libs/character-sheet/feature/src/lib/wiki/wiki-utils.ts
+++ b/libs/character-sheet/feature/src/lib/wiki/wiki-utils.ts
@@ -16,3 +16,41 @@ export function slugify(text: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
+/** Escape HTML special characters. */
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c] ?? c));
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Returns an HTML string with matched chars wrapped in `<mark class="hl">`.
+ * Returns `null` if the text does NOT match (entry should be hidden).
+ * Returns plain-escaped HTML when query is empty (show all, no mark).
+ */
+export function highlightMatch(text: string, query: string): string | null {
+  if (!query.trim()) return escapeHtml(text);
+  const normQ = normalizeStr(query);
+  if (!normQ) return escapeHtml(text);
+  if (!normalizeStr(text).includes(normQ)) return null;
+
+  const pattern = [...normQ]
+    .map(c => escapeRegex(c) + '[\\u0300-\\u036f]*')
+    .join('[\\u0300-\\u036f]*');
+  const regex = new RegExp(pattern, 'giu');
+
+  const nfdText = text.normalize('NFD');
+  let out = '';
+  let lastIdx = 0;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(nfdText)) !== null) {
+    out += escapeHtml(nfdText.slice(lastIdx, m.index).normalize('NFC'));
+    out += `<mark class="hl">${escapeHtml(m[0].normalize('NFC'))}</mark>`;
+    lastIdx = m.index + m[0].length;
+  }
+  out += escapeHtml(nfdText.slice(lastIdx).normalize('NFC'));
+  return out;
+}
+

--- a/libs/character-sheet/util/src/lib/quest-entry-form.ts
+++ b/libs/character-sheet/util/src/lib/quest-entry-form.ts
@@ -1,5 +1,4 @@
 export type QuestStatus = 'active' | 'completed' | 'failed' | 'inactive';
-export type QuestPriority = 'critical' | 'high' | 'medium' | 'low';
 
 export interface QuestEntry {
   id: string;
@@ -8,7 +7,6 @@ export interface QuestEntry {
   description: string;
   imageBase64: string | null;
   status: QuestStatus;
-  priority: QuestPriority;
   rewards: string;
   npcName: string;
   location: string;

--- a/libs/dm-page/feature/src/lib/dm-page-api.service.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-api.service.ts
@@ -56,6 +56,16 @@ export class DmPageApiService {
     }));
   }
 
+  // ── User existence check ─────────────────────────────────────────────────
+
+  /** Returns true if a character-sheet document exists for the given username. */
+  checkUserExists(username: string): Observable<boolean> {
+    return from(runInInjectionContext(this.injector, () => {
+      const ref = doc(this.firestore, `character-sheet/${username}`);
+      return getDoc(ref);
+    })).pipe(map(s => s.exists()));
+  }
+
   // ── Timeline Invitations ──────────────────────────────────────────────────
 
   getTimelineInvitation(viewerUsername: string): Observable<TimelineInvitationModel | undefined> {

--- a/libs/dm-page/feature/src/lib/dm-page-api.service.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-api.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable, Injector, runInInjectionContext } from '@angular/core';
-import { doc, Firestore, getDoc, setDoc } from '@angular/fire/firestore';
+import { deleteDoc, doc, Firestore, getDoc, setDoc } from '@angular/fire/firestore';
 import { from, map, Observable } from 'rxjs';
-import { DmNotesApiModel, DmQuestsApiModel, DmStoryTimelineApiModel } from './dm-page-models';
+import { DmNotesApiModel, DmQuestsApiModel, DmStoryTimelineApiModel, TimelineInvitationModel } from './dm-page-models';
 
 @Injectable({ providedIn: 'root' })
 export class DmPageApiService {
@@ -53,6 +53,29 @@ export class DmPageApiService {
     return from(runInInjectionContext(this.injector, () => {
       const ref = doc(this.firestore, `dm-story-timeline/${model.username}`);
       return setDoc(ref, model);
+    }));
+  }
+
+  // ── Timeline Invitations ──────────────────────────────────────────────────
+
+  getTimelineInvitation(viewerUsername: string): Observable<TimelineInvitationModel | undefined> {
+    return from(runInInjectionContext(this.injector, () => {
+      const ref = doc(this.firestore, `timeline-invitations/${viewerUsername}`);
+      return getDoc(ref);
+    })).pipe(map(s => (s.exists() ? (s.data() as TimelineInvitationModel) : undefined)));
+  }
+
+  setTimelineInvitation(model: TimelineInvitationModel): Observable<void> {
+    return from(runInInjectionContext(this.injector, () => {
+      const ref = doc(this.firestore, `timeline-invitations/${model.viewerUsername}`);
+      return setDoc(ref, model);
+    }));
+  }
+
+  removeTimelineInvitation(viewerUsername: string): Observable<void> {
+    return from(runInInjectionContext(this.injector, () => {
+      const ref = doc(this.firestore, `timeline-invitations/${viewerUsername}`);
+      return deleteDoc(ref);
     }));
   }
 }

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
@@ -381,6 +381,11 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
       gap: 16px;
     }
 
+    @media (max-width: 600px) {
+      :host { padding: 16px 12px 40px; }
+      .gen-grid { grid-template-columns: 1fr; }
+    }
+
     /* ── Card ────────────────────────────────────── */
     .gen-card {
       --c: rgba(160,145,110,.8);

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
@@ -489,10 +489,6 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
   `,
   template: `
     <div class="gen-header">
-      <div>
-        <div class="gen-title"><mat-icon>casino</mat-icon>Generátor PH</div>
-        <div class="gen-subtitle">Náhodné tabulky pro Pána Hry — jméno, počasí, setkání, zápletka a více</div>
-      </div>
       <button class="gen-reroll-all" type="button" (click)="rerollAll()" matTooltip="Přegenerovat všechny tabulky">
         <mat-icon>refresh</mat-icon>Generovat vše
       </button>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
@@ -353,10 +353,8 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
 
     /* ── Header ─────────────────────────────────── */
     .gen-header {
-      display: flex; align-items: flex-start; justify-content: space-between;
-      flex-wrap: wrap; gap: 14px; margin-bottom: 28px; padding-bottom: 14px;
-      border-bottom: 2px solid transparent;
-      border-image: linear-gradient(90deg, transparent, rgba(60,140,200,.6) 20%, rgba(80,180,240,.8) 50%, rgba(60,140,200,.6) 80%, transparent) 1;
+      display: flex; align-items: center; justify-content: flex-end;
+      flex-wrap: wrap; gap: 14px; margin-bottom: 20px;
     }
     .gen-title {
       font-size: 22px; letter-spacing: .12em; text-transform: uppercase;

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
@@ -349,7 +349,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MatIcon, MatTooltip],
   styles: `
-    :host { display: block; height: 100%; overflow-y: auto; padding: 24px 32px 40px; box-sizing: border-box; font-family: sans-serif; }
+    :host { display: block; height: 100%; overflow-y: auto; padding: 13px 0 20px; box-sizing: border-box; font-family: sans-serif; }
 
     /* ── Header ─────────────────────────────────── */
     .gen-header {
@@ -382,7 +382,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
     }
 
     @media (max-width: 600px) {
-      :host { padding: 16px 12px 40px; }
+      :host { padding: 13px 0 20px; }
       .gen-grid { grid-template-columns: 1fr; }
     }
 

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-generator/dm-generator.component.ts
@@ -364,15 +364,6 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
     }
     .gen-subtitle { font-size: 11px; color: rgba(60,140,200,.4); letter-spacing: .05em; margin-top: 5px; font-style: italic; text-transform: none; }
 
-    .gen-reroll-all {
-      font-size: 10px; letter-spacing: .1em; text-transform: uppercase;
-      border: 1px solid rgba(60,140,200,.3); border-radius: 3px; background: rgba(60,140,200,.08);
-      color: rgba(80,160,220,.8); padding: 6px 16px; cursor: pointer;
-      display: flex; align-items: center; gap: 6px;
-      transition: background .18s, border-color .18s, color .18s;
-      mat-icon { font-size: 15px; width: 15px; height: 15px; }
-      &:hover { background: rgba(60,140,200,.18); border-color: rgba(80,180,240,.5); color: #90d0f8; }
-    }
 
     /* ── Grid ────────────────────────────────────── */
     .gen-grid {
@@ -421,17 +412,6 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
       color: var(--c); flex: 1;
     }
 
-    .gen-btn {
-      font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
-      border: 1px solid var(--c); border-radius: 2px;
-      background: rgba(0,0,0,.2); color: var(--c);
-      padding: 4px 12px; cursor: pointer;
-      display: flex; align-items: center; gap: 4px;
-      transition: background .15s, opacity .15s;
-      mat-icon { font-size: 12px; width: 12px; height: 12px; }
-      &:hover { background: rgba(255,255,255,.06); }
-      &:active { opacity: .7; }
-    }
 
     .gen-card-body { padding: 12px 14px 14px; min-height: 64px; }
 
@@ -492,7 +472,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
   `,
   template: `
     <div class="gen-header">
-      <button class="gen-reroll-all" type="button" (click)="rerollAll()" matTooltip="Přegenerovat všechny tabulky">
+      <button class="pt-filter-btn" type="button" (click)="rerollAll()" matTooltip="Přegenerovat všechny tabulky">
         <mat-icon>refresh</mat-icon>Generovat vše
       </button>
     </div>
@@ -505,7 +485,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
         <div class="gen-card-header">
           <mat-icon class="gen-card-icon">person</mat-icon>
           <span class="gen-card-title">Jméno NPC</span>
-          <button class="gen-btn" type="button" (click)="rollNpc()"><mat-icon>shuffle</mat-icon>Generovat</button>
+          <button class="pt-filter-btn" type="button" (click)="rollNpc()"><mat-icon>shuffle</mat-icon>Generovat</button>
         </div>
         <div class="gen-card-body">
           @if (npc()) {
@@ -527,7 +507,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
         <div class="gen-card-header">
           <mat-icon class="gen-card-icon">wb_cloudy</mat-icon>
           <span class="gen-card-title">Počasí</span>
-          <button class="gen-btn" type="button" (click)="rollWeather()"><mat-icon>shuffle</mat-icon>Generovat</button>
+          <button class="pt-filter-btn" type="button" (click)="rollWeather()"><mat-icon>shuffle</mat-icon>Generovat</button>
         </div>
         <div class="gen-card-body">
           @if (weather()) {
@@ -544,7 +524,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
         <div class="gen-card-header">
           <mat-icon class="gen-card-icon">warning</mat-icon>
           <span class="gen-card-title">Náhodné setkání</span>
-          <button class="gen-btn" type="button" (click)="rollEncounter()"><mat-icon>shuffle</mat-icon>Generovat</button>
+          <button class="pt-filter-btn" type="button" (click)="rollEncounter()"><mat-icon>shuffle</mat-icon>Generovat</button>
         </div>
         <div class="gen-card-body">
           @if (encounter()) {
@@ -561,7 +541,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
         <div class="gen-card-header">
           <mat-icon class="gen-card-icon">psychology</mat-icon>
           <span class="gen-card-title">Zápletka</span>
-          <button class="gen-btn" type="button" (click)="rollPlot()"><mat-icon>shuffle</mat-icon>Generovat</button>
+          <button class="pt-filter-btn" type="button" (click)="rollPlot()"><mat-icon>shuffle</mat-icon>Generovat</button>
         </div>
         <div class="gen-card-body">
           @if (plot()) {
@@ -578,7 +558,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
         <div class="gen-card-header">
           <mat-icon class="gen-card-icon">door_back</mat-icon>
           <span class="gen-card-title">Popis místnosti</span>
-          <button class="gen-btn" type="button" (click)="rollRoom()"><mat-icon>shuffle</mat-icon>Generovat</button>
+          <button class="pt-filter-btn" type="button" (click)="rollRoom()"><mat-icon>shuffle</mat-icon>Generovat</button>
         </div>
         <div class="gen-card-body">
           @if (room()) {
@@ -595,7 +575,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
         <div class="gen-card-header">
           <mat-icon class="gen-card-icon">bolt</mat-icon>
           <span class="gen-card-title">Bojová komplikace</span>
-          <button class="gen-btn" type="button" (click)="rollComplication()"><mat-icon>shuffle</mat-icon>Generovat</button>
+          <button class="pt-filter-btn" type="button" (click)="rollComplication()"><mat-icon>shuffle</mat-icon>Generovat</button>
         </div>
         <div class="gen-card-body">
           @if (complication()) {
@@ -612,7 +592,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
         <div class="gen-card-header">
           <mat-icon class="gen-card-icon">auto_awesome</mat-icon>
           <span class="gen-card-title">Kořist</span>
-          <button class="gen-btn" type="button" (click)="rollLoot()"><mat-icon>shuffle</mat-icon>Generovat</button>
+          <button class="pt-filter-btn" type="button" (click)="rollLoot()"><mat-icon>shuffle</mat-icon>Generovat</button>
         </div>
 
         <!-- Budget control -->
@@ -655,7 +635,7 @@ const LOOT_PRESETS = [15, 80, 300, 1200] as const;
         <div class="gen-card-header">
           <mat-icon class="gen-card-icon">science</mat-icon>
           <span class="gen-card-title">Generovat loot ingredience</span>
-          <button class="gen-btn" type="button" (click)="rollAlchemy()"><mat-icon>shuffle</mat-icon>Generovat</button>
+          <button class="pt-filter-btn" type="button" (click)="rollAlchemy()"><mat-icon>shuffle</mat-icon>Generovat</button>
         </div>
 
         <div class="gen-loot-budget">

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -124,35 +124,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
       }
     }
 
-    .btn-save {
-      font-family: sans-serif;
-      font-size: 11px;
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-      border: 1px solid rgba(80, 160, 80, 0.35);
-      border-radius: 3px;
-      background: rgba(60, 120, 60, 0.08);
-      color: rgba(100, 200, 100, 0.8);
-      padding: 6px 14px;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      gap: 5px;
-      transition:
-        background 0.18s,
-        border-color 0.18s,
-        color 0.18s;
-      mat-icon {
-        font-size: 15px;
-        width: 15px;
-        height: 15px;
-      }
-      &:hover {
-        background: rgba(60, 140, 60, 0.18);
-        border-color: rgba(80, 180, 80, 0.6);
-        color: #80e080;
-      }
-    }
 
     /* ── Notes grid — 2 columns, full height ─────── */
     .notes-grid {
@@ -272,7 +243,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
           <mat-icon>check_circle</mat-icon>
           Automaticky uloženo
         </span>
-        <button class="btn-save" (click)="save()">
+        <button class="pt-filter-btn" (click)="save()">
           <mat-icon>save</mat-icon>
           Uložit
         </button>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -298,8 +298,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         <div class="note-panel panel--secrets">
           <div class="panel-header">
             <mat-icon class="panel-icon">lock</mat-icon>
-            <span class="panel-title">Tajemství &amp; Plány</span>
-            <span class="panel-desc">Co hráči nevědí, plot twists</span>
+            <span class="panel-title">Plány, NPC, Frakce, ...</span>
+            <span class="panel-desc">Co hráči nevědí</span>
           </div>
           <div class="rt-wrap">
             <rich-textarea

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -24,7 +24,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   styles: `
     :host {
       display: block;
-      padding: 24px 32px 40px;
+      padding: 13px 0 20px;
       font-family: sans-serif;
       overflow: visible;
       /* Pass a readable text colour into rich-textarea via the CSS custom property it supports */
@@ -158,12 +158,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
       display: flex;
       gap: 18px;
       align-items: stretch;
-      min-height: 600px;
+      min-height: calc(100vh - 180px);
     }
 
     @media (max-width: 700px) {
       :host {
-        padding: 16px 12px 40px;
+        padding: 13px 0 20px;
       }
       .notes-grid {
         flex-direction: column;

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -20,6 +20,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   selector: 'dm-notes',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { '(document:keydown.control.s)': 'ctrlSave($event)' },
   imports: [FormsModule, MatIcon, SpinnerOverlayComponent, RichTextareaComponent],
   styles: `
     :host {
@@ -358,6 +359,8 @@ export class DmNotesComponent {
   onAnyChange(): void {
     this.change$.next();
   }
+
+  ctrlSave(e: Event): void { e.preventDefault(); this.save(); }
 
   save(): void {
     const username = this.auth.currentUser()?.username;

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -151,6 +151,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
       gap: 18px;
     }
 
+    @media (max-width: 700px) {
+      :host { padding: 16px 12px 40px; }
+      .notes-grid { grid-template-columns: 1fr; }
+      .rt-wrap { height: 260px; }
+    }
+
     /* ── Single note panel ───────────────────────── */
     .note-panel {
       border-radius: 3px;

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -158,7 +158,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
       display: flex;
       gap: 18px;
       align-items: stretch;
-      min-height: calc(100vh - 180px);
+      min-height: calc(100vh - 120px);
     }
 
     @media (max-width: 700px) {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -153,11 +153,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
       }
     }
 
-    /* ── Notes grid — 2 × 2 ─────────────────────── */
+    /* ── Notes grid — 2 columns, full height ─────── */
     .notes-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+      display: flex;
       gap: 18px;
+      align-items: stretch;
+      min-height: 600px;
     }
 
     @media (max-width: 700px) {
@@ -165,15 +166,16 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         padding: 16px 12px 40px;
       }
       .notes-grid {
-        grid-template-columns: 1fr;
+        flex-direction: column;
       }
       .rt-wrap {
-        height: 260px;
+        min-height: 260px;
       }
     }
 
     /* ── Single note panel ───────────────────────── */
     .note-panel {
+      flex: 1;
       border-radius: 3px;
       overflow: hidden;
       background: linear-gradient(160deg, rgba(28, 22, 14, 0.97) 0%, rgba(18, 14, 8, 0.99) 100%);
@@ -182,6 +184,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         0 4px 20px rgba(0, 0, 0, 0.5),
         inset 0 1px 0 rgba(255, 255, 255, 0.02);
       transition: border-color 0.2s;
+      display: flex;
+      flex-direction: column;
       &:hover {
         border-color: rgba(255, 255, 255, 0.1);
       }
@@ -251,23 +255,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         color: rgba(170, 140, 230, 0.8);
       }
     }
-    .panel--rewards {
-      border-color: rgba(200, 160, 60, 0.2);
-      .panel-header {
-        background: rgba(200, 160, 60, 0.06);
-      }
-      .panel-icon {
-        color: rgba(200, 160, 60, 0.6);
-      }
-      .panel-title {
-        color: rgba(220, 180, 80, 0.85);
-      }
-    }
 
     /* ── Rich-textarea inside panel ─────────────── */
     .rt-wrap {
       position: relative;
-      height: 380px;
+      flex: 1;
+      min-height: 400px;
       background: rgba(0, 0, 0, 0.15);
     }
   `,
@@ -316,38 +309,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
             ></rich-textarea>
           </div>
         </div>
-
-        <!-- NPCs & Factions -->
-        <div class="note-panel panel--npcs">
-          <div class="panel-header">
-            <!--            <mat-icon class="panel-icon">groups</mat-icon>-->
-            <span class="panel-title">NPC, Frakce, Vztahy</span>
-            <!--            <span class="panel-desc">Postavy, vztahy, frakce</span>-->
-          </div>
-          <div class="rt-wrap">
-            <rich-textarea
-              [(ngModel)]="npcsAndFactions"
-              (ngModelChange)="onAnyChange()"
-              style="top:0;left:0;width:100%;height:100%;"
-            ></rich-textarea>
-          </div>
-        </div>
-
-        <!-- Rewards & Treasure -->
-        <div class="note-panel panel--rewards">
-          <div class="panel-header">
-<!--            <mat-icon class="panel-icon">auto_awesome</mat-icon>-->
-            <span class="panel-title">NPC, Frakce, Vztahy</span>
-<!--            <span class="panel-desc">Magické předměty, zlato, XP</span>-->
-          </div>
-          <div class="rt-wrap">
-            <rich-textarea
-              [(ngModel)]="rewards"
-              (ngModelChange)="onAnyChange()"
-              style="top:0;left:0;width:100%;height:100%;"
-            ></rich-textarea>
-          </div>
-        </div>
       </div>
     </spinner-overlay>
   `,
@@ -360,8 +321,6 @@ export class DmNotesComponent {
 
   worldNotes = '';
   secrets = '';
-  npcsAndFactions = '';
-  rewards = '';
   autoSaved = signal(false);
 
   private readonly change$ = new Subject<void>();
@@ -374,8 +333,6 @@ export class DmNotesComponent {
         if (data) {
           this.worldNotes = data.worldNotes ?? '';
           this.secrets = data.secrets ?? '';
-          this.npcsAndFactions = data.npcsAndFactions ?? '';
-          this.rewards = data.rewards ?? '';
           // With OnPush, plain-property mutations are invisible to Angular's CD.
           // markForCheck() schedules a re-check so ngModel propagates to rich-textarea.
           this.cdr.markForCheck();
@@ -409,8 +366,6 @@ export class DmNotesComponent {
       username,
       worldNotes: this.worldNotes,
       secrets: this.secrets,
-      npcsAndFactions: this.npcsAndFactions,
-      rewards: this.rewards,
     };
     this.store.saveDmNotes(model);
   }

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -90,6 +90,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
       display: flex;
       gap: 8px;
       align-items: center;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+      margin-bottom: 14px;
     }
 
     .autosave-indicator {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -249,24 +249,15 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   `,
   template: `
     <spinner-overlay [showSpinner]="store.loading()" [diameter]="50">
-      <div class="header">
-        <div>
-          <div class="header-title">
-            <mat-icon>import_contacts</mat-icon>
-            Zápisník Pána Hry
-          </div>
-          <div class="header-subtitle">Soukromé poznámky PH — obsah není sdílen s hráči</div>
-        </div>
-        <div class="header-actions">
-          <span class="autosave-indicator" [class.autosave-indicator--hidden]="!autoSaved()">
-            <mat-icon>check_circle</mat-icon>
-            Automaticky uloženo
-          </span>
-          <button class="btn-save" (click)="save()">
-            <mat-icon>save</mat-icon>
-            Uložit
-          </button>
-        </div>
+      <div class="header-actions">
+        <span class="autosave-indicator" [class.autosave-indicator--hidden]="!autoSaved()">
+          <mat-icon>check_circle</mat-icon>
+          Automaticky uloženo
+        </span>
+        <button class="btn-save" (click)="save()">
+          <mat-icon>save</mat-icon>
+          Uložit
+        </button>
       </div>
 
       <div class="notes-grid">

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-notes/dm-notes.component.ts
@@ -37,9 +37,18 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
       background: rgba(22, 14, 6, 0.97) !important;
       border-color: rgba(200, 160, 60, 0.3) !important;
       box-shadow: 0 2px 10px rgba(0, 0, 0, 0.7) !important;
-      button { color: rgba(220, 195, 130, 0.85); &:hover { background: rgba(200,160,60,.14) !important; border-color: rgba(200,160,60,.4) !important; color: #e8c96a; } }
+      button {
+        color: rgba(220, 195, 130, 0.85);
+        &:hover {
+          background: rgba(200, 160, 60, 0.14) !important;
+          border-color: rgba(200, 160, 60, 0.4) !important;
+          color: #e8c96a;
+        }
+      }
     }
-    :host ::ng-deep rich-textarea .rt-separator { background: rgba(200, 160, 60, 0.25); }
+    :host ::ng-deep rich-textarea .rt-separator {
+      background: rgba(200, 160, 60, 0.25);
+    }
 
     /* ── Header ─────────────────────────────────── */
     .header {
@@ -152,9 +161,15 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     }
 
     @media (max-width: 700px) {
-      :host { padding: 16px 12px 40px; }
-      .notes-grid { grid-template-columns: 1fr; }
-      .rt-wrap { height: 260px; }
+      :host {
+        padding: 16px 12px 40px;
+      }
+      .notes-grid {
+        grid-template-columns: 1fr;
+      }
+      .rt-wrap {
+        height: 260px;
+      }
     }
 
     /* ── Single note panel ───────────────────────── */
@@ -273,9 +288,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         <!-- World notes -->
         <div class="note-panel panel--world">
           <div class="panel-header">
-            <mat-icon class="panel-icon">public</mat-icon>
-            <span class="panel-title">Světové Poznámky</span>
-            <span class="panel-desc">Lore, lokace, pravidla světa</span>
+            <!--            <mat-icon class="panel-icon">public</mat-icon>-->
+            <span class="panel-title">Hlavní info</span>
+            <!--            <span class="panel-desc">Lore, lokace, pravidla světa</span>-->
           </div>
           <div class="rt-wrap">
             <rich-textarea
@@ -305,9 +320,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         <!-- NPCs & Factions -->
         <div class="note-panel panel--npcs">
           <div class="panel-header">
-            <mat-icon class="panel-icon">groups</mat-icon>
-            <span class="panel-title">NPC &amp; Frakce</span>
-            <span class="panel-desc">Postavy, vztahy, frakce</span>
+            <!--            <mat-icon class="panel-icon">groups</mat-icon>-->
+            <span class="panel-title">NPC, Frakce, Vztahy</span>
+            <!--            <span class="panel-desc">Postavy, vztahy, frakce</span>-->
           </div>
           <div class="rt-wrap">
             <rich-textarea
@@ -321,9 +336,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         <!-- Rewards & Treasure -->
         <div class="note-panel panel--rewards">
           <div class="panel-header">
-            <mat-icon class="panel-icon">auto_awesome</mat-icon>
-            <span class="panel-title">Odměny &amp; Poklady</span>
-            <span class="panel-desc">Magické předměty, zlato, XP</span>
+<!--            <mat-icon class="panel-icon">auto_awesome</mat-icon>-->
+            <span class="panel-title">NPC, Frakce, Vztahy</span>
+<!--            <span class="panel-desc">Magické předměty, zlato, XP</span>-->
           </div>
           <div class="rt-wrap">
             <rich-textarea

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -268,20 +268,13 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
   `,
   template: `
     <spinner-overlay [showSpinner]="store.loading()" [diameter]="50">
-      <!-- Header -->
-      <div class="header">
-        <div>
-          <div class="header-title"><mat-icon>gavel</mat-icon>DM Questy &amp; Příběhy</div>
-          <div class="header-subtitle">Pouze pro Pána Hry — hráči tuto stránku nevidí</div>
-        </div>
-        <div class="header-actions">
-          <button class="btn btn-icon" type="button" (click)="toggleAllExpanded()"
-            [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
-            <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
-          </button>
-          <button class="btn" type="button" (click)="addQuest()"><mat-icon>add</mat-icon>Přidat quest</button>
-          <button class="btn btn-save" type="button" (click)="save()"><mat-icon>save</mat-icon>Uložit</button>
-        </div>
+      <div class="header-actions">
+        <button class="btn btn-icon" type="button" (click)="toggleAllExpanded()"
+          [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
+          <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+        </button>
+        <button class="btn" type="button" (click)="addQuest()"><mat-icon>add</mat-icon>Přidat quest</button>
+        <button class="btn btn-save" type="button" (click)="save()"><mat-icon>save</mat-icon>Uložit</button>
       </div>
 
       <!-- Filter bar -->

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -24,7 +24,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
   selector: 'dm-quests',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormsModule, MatIcon, MatIconButton, MatTooltip, SpinnerOverlayComponent, RichTextareaComponent],
-  host: { '(document:keydown.escape)': 'onEscape()', 'class': 'theme-dark' },
+  host: { '(document:keydown.escape)': 'onEscape()', '(document:keydown.control.s)': 'ctrlSave($event)', 'class': 'theme-dark' },
   styles: `
     :host { display: block; padding: 13px 0 20px; font-family: sans-serif; overflow: visible; }
 
@@ -467,6 +467,7 @@ export class DmQuestsComponent {
   }
 
   onEscape(): void { if (this.confirmIdx() !== null) this.cancelDelete(); }
+  ctrlSave(e: Event): void { e.preventDefault(); this.save(); }
 
   // ── Labels / colours ─────────────────────────────────────────────────────
   diffLabel(d: DmQuestDifficulty): string {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -3,11 +3,9 @@ import {
   Component,
   computed,
   effect,
-  ElementRef,
   inject,
   signal,
   untracked,
-  viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatIcon } from '@angular/material/icon';
@@ -15,7 +13,6 @@ import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
 import { SpinnerOverlayComponent, RichTextareaComponent } from '@dn-d-servant/ui';
 import { AuthService } from '@dn-d-servant/util';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { DmPageStore } from '../../dm-page.store';
 import { DmQuestDifficulty, DmQuestEntry, DmQuestStatus } from '../../dm-page-models';
 
@@ -58,15 +55,13 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
     /* ── Card ────────────────────────────────────── */
     .quest-card {
       position: relative; border-radius: 3px;
-      background: linear-gradient(160deg, rgba(38,22,18,.97) 0%, rgba(24,12,10,.99) 100%);
+      background: rgba(22,20,18,.97);
       border: 1px solid rgba(200,80,60,.15);
       border-left: 3px solid transparent;
-      box-shadow: 0 4px 20px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,120,100,.03);
+      box-shadow: 0 4px 20px rgba(0,0,0,.55);
       transition: border-color .2s, box-shadow .2s;
-      &::before { content: '◆'; position: absolute; top: 5px; left: 8px; font-size: 6px; color: rgba(200,80,60,.2); pointer-events: none; }
-      &:hover { border-color: rgba(200,80,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65), 0 0 10px rgba(200,80,60,.05); }
+      &:hover { border-color: rgba(200,80,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65); }
     }
-    .quest-card-rule { height: 2px; background: linear-gradient(90deg, rgba(200,80,60,.0) 0%, rgba(200,80,60,.4) 30%, rgba(240,100,80,.6) 50%, rgba(200,80,60,.4) 70%, rgba(200,80,60,.0) 100%); }
 
     /* ── Card header ─────────────────────────────── */
     .card-header { display: flex; align-items: center; gap: 6px; padding: 10px 10px 7px; flex-wrap: wrap; cursor: pointer; user-select: none;
@@ -105,10 +100,11 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
     .card-header-spacer { flex: 1; min-width: 0; }
     .card-btns { display: flex; flex-shrink: 0; }
     .expand-btn, .delete-btn {
-      width: 44px !important; height: 44px !important; padding: 0 !important;
+      width: 26px !important; height: 26px !important;
+      padding: 0 !important; line-height: 1 !important;
       display: inline-flex !important; align-items: center !important; justify-content: center !important;
-      border-radius: 3px !important; transition: color .15s, background .15s !important;
-      mat-icon, .mat-icon { font-size: 24px !important; width: 24px !important; height: 24px !important; display: flex !important; align-items: center !important; justify-content: center !important; }
+      border-radius: 2px !important; transition: color .15s, background .15s !important;
+      mat-icon, .mat-icon { font-size: 16px !important; width: 16px !important; height: 16px !important; line-height: 16px !important; display: flex !important; align-items: center !important; justify-content: center !important; }
       .mat-mdc-button-touch-target, .mat-mdc-button-persistent-ripple, .mdc-icon-button__ripple { display: none !important; }
     }
     .expand-btn { color: rgba(200,80,60,.4) !important; &:hover { color: rgba(200,80,60,.85) !important; background: rgba(200,80,60,.08) !important; } }
@@ -128,33 +124,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
 
     /* ── Expanded body ───────────────────────────── */
     .expanded-body { padding: 0 12px 14px; }
-
-    /* ── Image area ──────────────────────────────── */
-    .image-wrap {
-      position: relative; height: 120px;
-      background: repeating-linear-gradient(45deg, rgba(200,80,60,.02) 0px, rgba(200,80,60,.02) 1px, transparent 1px, transparent 8px), rgba(14,8,6,.5);
-      display: flex; align-items: center; justify-content: center; overflow: hidden;
-      cursor: pointer; border-bottom: 1px solid rgba(200,80,60,.08); transition: background .18s;
-      img { width: 100%; height: 100%; object-fit: cover; }
-      .img-placeholder { display: flex; flex-direction: column; align-items: center; gap: 6px; color: rgba(200,80,60,.22); font-size: 9px; letter-spacing: .1em; text-transform: uppercase; pointer-events: none;
-        mat-icon { font-size: 26px; width: 26px; height: 26px; }
-      }
-      .img-overlay { position: absolute; inset: 0; background: rgba(0,0,0,.5); display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity .18s; pointer-events: none;
-        mat-icon { color: #e8a090; font-size: 22px; width: 22px; height: 22px; }
-      }
-      &:hover .img-overlay { opacity: 1; }
-      &.drag-over { box-shadow: inset 0 0 0 2px rgba(200,80,60,.5); .img-overlay { opacity: 1; background: rgba(200,80,60,.1); } }
-    }
-    .img-view-btn {
-      position: absolute; top: 5px; right: 5px; z-index: 2;
-      width: 22px !important; height: 22px !important; padding: 0 !important;
-      background: rgba(0,0,0,.6) !important; color: rgba(200,80,60,.8) !important; border-radius: 2px !important;
-      display: inline-flex !important; align-items: center !important; justify-content: center !important;
-      mat-icon, .mat-icon { font-size: 12px !important; width: 12px !important; height: 12px !important; }
-      .mat-mdc-button-touch-target, .mat-mdc-button-persistent-ripple, .mdc-icon-button__ripple { display: none !important; }
-      &:hover { background: rgba(0,0,0,.85) !important; color: #e8a090 !important; }
-    }
-    .img-file-input { display: none; }
 
     /* ── Meta fields ─────────────────────────────── */
     .meta-row { display: flex; flex-direction: column; gap: 5px; margin-top: 10px; }
@@ -205,12 +174,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
       &:hover { background: rgba(50,160,50,.15) !important; border-color: rgba(80,180,80,.5) !important; }
     }
 
-    /* ── Collapsed image thumbnail ───────────────── */
-    .collapsed-thumb {
-      height: 70px; overflow: hidden; border-top: 1px solid rgba(200,80,60,.1);
-      img { width: 100%; height: 100%; object-fit: cover; opacity: 0.65; display: block; }
-    }
-
     /* ── Stage bar ───────────────────────────────── */
     .stage-bar { display: flex; gap: 1px; margin-top: 10px; margin-bottom: 2px; }
     .stage-seg {
@@ -235,21 +198,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
     .confirm-btn { font-family: sans-serif; font-size: 10px; letter-spacing: .1em; text-transform: uppercase; border-radius: 3px; padding: 7px 20px; cursor: pointer; transition: background .18s, border-color .18s, color .18s; }
     .confirm-cancel { background: rgba(200,80,60,.06); border: 1px solid rgba(200,80,60,.25); color: rgba(200,80,60,.65); &:hover { background: rgba(200,80,60,.14); border-color: rgba(200,80,60,.5); color: #e8a090; } }
     .confirm-delete { background: rgba(160,40,30,.25); border: 1px solid rgba(200,60,50,.4); color: rgba(220,100,80,.85); &:hover { background: rgba(180,40,30,.45); border-color: rgba(220,80,60,.7); color: #ff9980; } }
-
-    /* ── Image preview ───────────────────────────── */
-    .preview-backdrop { position: fixed; inset: 0; z-index: 9999; background: rgba(0,0,0,.88); display: flex; align-items: center; justify-content: center; cursor: zoom-out; animation: fadeIn .18s ease; }
-    .preview-container { position: relative; max-width: 90vw; max-height: 88vh; cursor: default; display: flex; flex-direction: column; align-items: center; animation: scaleIn .18s ease; }
-    .preview-title { font-family: sans-serif; font-size: 13px; letter-spacing: .12em; text-transform: uppercase; color: #e8a090; margin-bottom: 12px; }
-    .preview-frame { border: 1px solid rgba(200,80,60,.35); box-shadow: 0 0 0 1px rgba(0,0,0,.8), 0 8px 40px rgba(0,0,0,.9); background: rgba(14,6,4,.95); padding: 6px; img { display: block; max-width: 88vw; max-height: 78vh; object-fit: contain; } }
-    .preview-close {
-      position: absolute; top: -14px; right: -14px; width: 28px !important; height: 28px !important; padding: 0 !important;
-      background: rgba(40,14,10,.98) !important; border: 1px solid rgba(200,80,60,.4) !important; color: #c05040 !important; border-radius: 3px !important;
-      display: inline-flex !important; align-items: center !important; justify-content: center !important;
-      mat-icon, .mat-icon { font-size: 15px !important; width: 15px !important; height: 15px !important; display: flex !important; align-items: center !important; justify-content: center !important; }
-      .mat-mdc-button-touch-target, .mat-mdc-button-persistent-ripple, .mdc-icon-button__ripple { display: none !important; }
-      &:hover { background: rgba(200,80,60,.15) !important; color: #e8a090 !important; }
-    }
-    .preview-hint { margin-top: 10px; font-size: 10px; color: rgba(200,80,60,.3); letter-spacing: .1em; }
 
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     @keyframes scaleIn { from { transform: scale(.92); opacity: 0; } to { transform: scale(1); opacity: 1; } }
@@ -281,7 +229,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
 
         @for (item of filtered(); track item.quest.id) {
           <div class="quest-card" [style.border-left-color]="statusColor(item.quest.status)">
-            <div class="quest-card-rule"></div>
 
             <!-- Card header -->
             <div class="card-header" (click)="toggleExpand(item.quest.id)">
@@ -329,31 +276,8 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
               }
             </div>
 
-            <!-- Collapsed image preview -->
-            @if (!expandedIds().has(item.quest.id) && quests()[item.idx].imageBase64) {
-              <div class="collapsed-thumb">
-                <img [src]="'data:image/png;base64,' + quests()[item.idx].imageBase64" [alt]="quests()[item.idx].title" />
-              </div>
-            }
-
             @if (expandedIds().has(item.quest.id)) {
               <div class="expanded-body">
-                <!-- Image -->
-                <div class="image-wrap" [class.drag-over]="dragOver() === item.idx"
-                  (click)="selectImage(item.idx)" (dragover)="onDragOver($event, item.idx)"
-                  (dragleave)="dragOver.set(null)" (drop)="onDrop($event, item.idx)"
-                  matTooltip="Klikni nebo přetáhni obrázek (max 200 KB)">
-                  @if (quests()[item.idx].imageBase64) {
-                    <img [src]="'data:image/png;base64,' + quests()[item.idx].imageBase64" [alt]="quests()[item.idx].title" />
-                    <button mat-icon-button class="img-view-btn" type="button" (click)="openPreview($event, quests()[item.idx])" matTooltip="Plná velikost">
-                      <mat-icon>open_in_full</mat-icon>
-                    </button>
-                  } @else {
-                    <div class="img-placeholder"><mat-icon>image_search</mat-icon>Obrázek questu</div>
-                  }
-                  <div class="img-overlay"><mat-icon>upload</mat-icon></div>
-                </div>
-
                 <!-- Meta -->
                 <div class="meta-row">
                   <div class="meta-field"><mat-icon class="meta-icon">place</mat-icon>
@@ -388,8 +312,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
       </div>
     </spinner-overlay>
 
-    <input #globalFile type="file" accept="image/*" class="img-file-input" (change)="onImageSelected($event)" />
-
     @if (confirmIdx() !== null) {
       <div class="confirm-backdrop" (click)="cancelDelete()">
         <div class="confirm-dialog" (click)="$event.stopPropagation()">
@@ -407,31 +329,16 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
       </div>
     }
 
-    @if (previewQuest()) {
-      <div class="preview-backdrop" (click)="closePreview()">
-        <div class="preview-container" (click)="$event.stopPropagation()">
-          <button mat-icon-button class="preview-close" (click)="closePreview()"><mat-icon>close</mat-icon></button>
-          @if (previewQuest()!.title) { <div class="preview-title">{{ previewQuest()!.title }}</div> }
-          <div class="preview-frame"><img [src]="'data:image/png;base64,' + previewQuest()!.imageBase64" [alt]="previewQuest()!.title" /></div>
-          <div class="preview-hint">Klikni mimo nebo Esc pro zavření</div>
-        </div>
-      </div>
-    }
   `,
 })
 export class DmQuestsComponent {
   readonly store = inject(DmPageStore);
   private readonly auth = inject(AuthService);
-  private readonly snack = inject(MatSnackBar);
 
   quests = signal<DmQuestEntry[]>([]);
   filterStatus = signal<FilterStatus>('all');
   expandedIds = signal<Set<string>>(new Set());
   confirmIdx = signal<number | null>(null);
-  dragOver = signal<number | null>(null);
-  previewQuest = signal<DmQuestEntry | null>(null);
-  private pendingFileIdx = signal<number | null>(null);
-  private readonly globalFile = viewChild<ElementRef<HTMLInputElement>>('globalFile');
 
   readonly filterTabs: { value: FilterStatus; label: string }[] = [
     { value: 'all', label: 'Vše' },
@@ -526,39 +433,20 @@ export class DmQuestsComponent {
     this.store.saveDmQuests({ username, quests: this.quests() });
   }
 
-  // ── Image ────────────────────────────────────────────────────────────────
-  selectImage(idx: number): void { this.pendingFileIdx.set(idx); this.globalFile()?.nativeElement.click(); }
-  onDragOver(e: DragEvent, idx: number): void { e.preventDefault(); e.stopPropagation(); if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'; this.dragOver.set(idx); }
-  onDrop(e: DragEvent, idx: number): void { e.preventDefault(); e.stopPropagation(); this.dragOver.set(null); const f = e.dataTransfer?.files?.[0]; if (f) this.processFile(f, idx); }
-  onImageSelected(e: Event): void {
-    const idx = this.pendingFileIdx(); if (idx === null) return;
-    const input = e.target as HTMLInputElement; const file = input.files?.[0]; if (!file) return;
-    this.processFile(file, idx); input.value = ''; this.pendingFileIdx.set(null);
-  }
-  private processFile(file: File, idx: number): void {
-    if (!file.type.startsWith('image/')) { this.snack.open('Soubor není obrázek.', 'Zavřít', { verticalPosition: 'top', duration: 3000 }); return; }
-    if (file.size > 200 * 1024) { this.snack.open(`Obrázek příliš velký (${(file.size/1024).toFixed(0)} KB). Max 200 KB.`, 'Zavřít', { verticalPosition: 'top', duration: 5000 }); return; }
-    const reader = new FileReader();
-    reader.onload = () => {
-      const base64 = (reader.result as string).split(',')[1];
-      this.quests.update(list => { const c = list.map(q => ({ ...q })); c[idx] = { ...c[idx], imageBase64: base64 }; return c; });
-    };
-    reader.readAsDataURL(file);
-  }
-  openPreview(e: MouseEvent, q: DmQuestEntry): void { e.stopPropagation(); this.previewQuest.set(q); }
-  closePreview(): void { this.previewQuest.set(null); }
-
-  onEscape(): void { if (this.previewQuest()) { this.closePreview(); return; } if (this.confirmIdx() !== null) this.cancelDelete(); }
+  onEscape(): void { if (this.confirmIdx() !== null) this.cancelDelete(); }
 
   // ── Labels / colours ─────────────────────────────────────────────────────
   statusLabel(s: DmQuestStatus): string {
-    return { planned: 'Naplánováno', active: 'Aktivní', climax: 'Vyvrcholení', completed: 'Dokončeno', abandoned: 'Opuštěno' }[s];
+    const map: Record<DmQuestStatus, string> = { planned: 'Naplánováno', active: 'Aktivní', climax: 'Vyvrcholení', completed: 'Dokončeno', abandoned: 'Opuštěno' };
+    return map[s];
   }
   diffLabel(d: DmQuestDifficulty): string {
-    return { trivial: 'Trivální', easy: 'Lehké', medium: 'Střední', hard: 'Těžké', deadly: 'Smrtelné' }[d];
+    const map: Record<DmQuestDifficulty, string> = { trivial: 'Trivální', easy: 'Lehké', medium: 'Střední', hard: 'Těžké', deadly: 'Smrtelné' };
+    return map[d];
   }
   statusColor(s: DmQuestStatus): string {
-    return { planned: 'rgba(100,130,200,.8)', active: 'rgba(80,190,100,.8)', climax: 'rgba(220,120,40,.9)', completed: 'rgba(200,160,60,.85)', abandoned: 'rgba(80,80,80,.5)' }[s];
+    const map: Record<DmQuestStatus, string> = { planned: 'rgba(100,130,200,.8)', active: 'rgba(80,190,100,.8)', climax: 'rgba(220,120,40,.9)', completed: 'rgba(200,160,60,.85)', abandoned: 'rgba(80,80,80,.5)' };
+    return map[s];
   }
   stageName(n: number): string { return STAGE_LABELS[n - 1] ?? ''; }
 }

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -268,16 +268,7 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
   `,
   template: `
     <spinner-overlay [showSpinner]="store.loading()" [diameter]="50">
-      <div class="header-actions">
-        <button class="btn btn-icon" type="button" (click)="toggleAllExpanded()"
-          [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
-          <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
-        </button>
-        <button class="btn" type="button" (click)="addQuest()"><mat-icon>add</mat-icon>Přidat quest</button>
-        <button class="btn btn-save" type="button" (click)="save()"><mat-icon>save</mat-icon>Uložit</button>
-      </div>
-
-      <!-- Filter bar -->
+      <!-- Filter bar + actions in one row -->
       <div class="filter-bar">
         <div class="filter-tabs">
           @for (t of filterTabs; track t.value) {
@@ -285,6 +276,14 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
               {{ t.label }}<span class="filter-count">{{ counts()[t.value] }}</span>
             </button>
           }
+        </div>
+        <div class="bar-actions">
+          <button class="btn btn-icon" type="button" (click)="toggleAllExpanded()"
+            [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
+            <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+          </button>
+          <button class="btn" type="button" (click)="addQuest()"><mat-icon>add</mat-icon>Přidat quest</button>
+          <button class="btn btn-save" type="button" (click)="save()"><mat-icon>save</mat-icon>Uložit</button>
         </div>
       </div>
 

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -198,24 +198,34 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
       <!-- Filter bar + actions in one row -->
       <div class="filter-bar">
         @for (t of filterTabs; track t.value) {
-          <button type="button" class="pt-filter-btn" [class.active]="filterStatus() === t.value" (click)="filterStatus.set(t.value)">
+          <button type="button" class="pt-filter-btn" [class.active]="filterStatus() === t.value"
+                  (click)="filterStatus.set(t.value)">
             {{ t.label }}<span class="filter-count">{{ counts()[t.value] }}</span>
           </button>
         }
         <div class="bar-actions">
           <button class="btn btn-icon" type="button" (click)="toggleAllExpanded()"
-            [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
+                  [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
             <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
           </button>
-          <button class="btn" type="button" (click)="addQuest()"><mat-icon>add</mat-icon>Přidat quest</button>
-          <button class="btn btn-save" type="button" (click)="save()"><mat-icon>save</mat-icon>Uložit</button>
+          <button class="btn" type="button" (click)="addQuest()">
+            <mat-icon>add</mat-icon>
+            Přidat quest
+          </button>
+          <button class="btn btn-save" type="button" (click)="save()">
+            <mat-icon>save</mat-icon>
+            Uložit
+          </button>
         </div>
       </div>
 
       <!-- Grid -->
       <div class="quest-grid">
         @if (filtered().length === 0) {
-          <div class="empty-state"><mat-icon>auto_stories</mat-icon>Žádné questy. Začni psát příběh!</div>
+          <div class="empty-state">
+            <mat-icon>auto_stories</mat-icon>
+            Žádné questy. Začni psát příběh!
+          </div>
         }
 
         @for (item of filtered(); track item.quest.id) {
@@ -224,12 +234,14 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
             <!-- Card header -->
             <div class="card-header" (click)="toggleExpand(item.quest.id)">
               <button class="diff-badge diff-badge--{{ item.quest.difficulty }}" type="button"
-                (click)="cycleDiff(item.idx); $event.stopPropagation()" matTooltip="Obtížnost — klikni pro změnu" matTooltipShowDelay="400">{{ diffLabel(item.quest.difficulty) }}</button>
+                      (click)="cycleDiff(item.idx); $event.stopPropagation()" matTooltip="Obtížnost — klikni pro změnu"
+                      matTooltipShowDelay="400">{{ diffLabel(item.quest.difficulty) }}
+              </button>
               <!-- Stage pips -->
               <div class="stage-pips">
-                @for (n of [1,2,3,4]; track n) {
+                @for (n of [1, 2, 3, 4]; track n) {
                   <span class="stage-pip" [class.stage-pip--filled]="n <= item.quest.stage"
-                    (click)="setStage(item.idx, n); $event.stopPropagation()" [matTooltip]="stageName(n)"></span>
+                        (click)="setStage(item.idx, n); $event.stopPropagation()" [matTooltip]="stageName(n)"></span>
                 }
               </div>
               @if (item.quest.stage >= 4) {
@@ -238,10 +250,11 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
               <span class="card-header-spacer"></span>
               <div class="card-btns">
                 <button mat-icon-button class="expand-btn" type="button"
-                  [matTooltip]="expandedIds().has(item.quest.id) ? 'Sbalit' : 'Rozbalit'">
+                        [matTooltip]="expandedIds().has(item.quest.id) ? 'Sbalit' : 'Rozbalit'">
                   <mat-icon>{{ expandedIds().has(item.quest.id) ? 'expand_less' : 'expand_more' }}</mat-icon>
                 </button>
-                <button mat-icon-button class="delete-btn" type="button" (click)="askDelete(item.idx); $event.stopPropagation()" matTooltip="Smazat">
+                <button mat-icon-button class="delete-btn" type="button"
+                        (click)="askDelete(item.idx); $event.stopPropagation()" matTooltip="Smazat">
                   <mat-icon>delete_outline</mat-icon>
                 </button>
               </div>
@@ -249,17 +262,20 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
 
             <!-- Title -->
             <div class="title-row">
-              <input class="title-input" [(ngModel)]="quests()[item.idx].title" placeholder="Název questu / příběhu..." (click)="$event.stopPropagation()" />
+              <input class="title-input" [(ngModel)]="quests()[item.idx].title" placeholder="Název questu / příběhu..."
+                     (click)="$event.stopPropagation()" />
               <div class="card-meta-peek">
                 @if (item.quest.dateAdded) {
                   <span class="card-date">{{ item.quest.dateAdded }}</span>
                   <span class="peek-sep">·</span>
                 }
                 <mat-icon class="peek-icon">place</mat-icon>
-                <input class="peek-input" [(ngModel)]="quests()[item.idx].location" placeholder="Lokalita..." (click)="$event.stopPropagation()" />
+                <input class="peek-input" [(ngModel)]="quests()[item.idx].location" placeholder="Lokalita..."
+                       (click)="$event.stopPropagation()" />
                 <span class="peek-sep">·</span>
                 <mat-icon class="peek-icon" style="color:rgba(200,80,60,.35)">whatshot</mat-icon>
-                <input class="peek-input" [(ngModel)]="quests()[item.idx].antagonist" placeholder="Antagonista..." (click)="$event.stopPropagation()" />
+                <input class="peek-input" [(ngModel)]="quests()[item.idx].antagonist" placeholder="Co je cílem..."
+                       (click)="$event.stopPropagation()" />
               </div>
             </div>
 
@@ -268,21 +284,25 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
 
                 <!-- ⚔ Player-visible textarea -->
                 <div class="rt-wrap rt-wrap--player">
-                  <rich-textarea [(ngModel)]="quests()[item.idx].playerDescription" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
+                  <rich-textarea [(ngModel)]="quests()[item.idx].playerDescription"
+                                 style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
                 </div>
                 <div class="reward-row">
                   <mat-icon class="reward-icon" style="color:rgba(200,160,60,.55)">payments</mat-icon>
-                  <input class="reward-input" [(ngModel)]="quests()[item.idx].publicRewards" placeholder="Veřejná odměna (hráči to ví)..." />
+                  <input class="reward-input" [(ngModel)]="quests()[item.idx].publicRewards"
+                         placeholder="Dohodnutá odměna..." />
                 </div>
 
                 <!-- 🔒 DM-only textarea -->
-                <div class="rt-label">Info pro PH</div>
-                <div class="rt-wrap">
-                  <rich-textarea [(ngModel)]="quests()[item.idx].dmNotes" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
+                <div class="rt-label" style="font-size: 11px; margin-top: 15px; color: #ba4242;">Info pro PH</div>
+                <div class="rt-wrap" style="margin-top: 4px;">
+                  <rich-textarea [(ngModel)]="quests()[item.idx].dmNotes"
+                                 style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
                 </div>
                 <div class="reward-row">
                   <mat-icon class="reward-icon" style="color:rgba(200,60,50,.5)">lock</mat-icon>
-                  <input class="reward-input reward-input--secret" [(ngModel)]="quests()[item.idx].secretRewards" placeholder="Tajná odměna / DM plán..." />
+                  <input class="reward-input reward-input--secret" [(ngModel)]="quests()[item.idx].secretRewards"
+                         placeholder="Tajná/alternativní odměna..." />
                 </div>
               </div>
             }
@@ -294,10 +314,16 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     @if (confirmIdx() !== null) {
       <div class="confirm-backdrop" (click)="cancelDelete()">
         <div class="confirm-dialog" (click)="$event.stopPropagation()">
-          <div class="confirm-icon"><mat-icon>delete_forever</mat-icon></div>
+          <div class="confirm-icon">
+            <mat-icon>delete_forever</mat-icon>
+          </div>
           <div class="confirm-title">Smazat quest?</div>
           <div class="confirm-msg">Opravdu smazat quest
-            @if (quests()[confirmIdx()!]?.title) { <strong>„{{ quests()[confirmIdx()!].title }}"</strong> } @else { <strong>bez názvu</strong> }?
+            @if (quests()[confirmIdx()!]?.title) {
+              <strong>„{{ quests()[confirmIdx()!].title }}"</strong>
+            } @else {
+              <strong>bez názvu</strong>
+            }?
           </div>
           <div class="confirm-rule"></div>
           <div class="confirm-actions">

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -48,7 +48,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     /* ── Grid ────────────────────────────────────── */
     .quest-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; align-items: start; }
     .empty-state { grid-column: 1 / -1; text-align: center; padding: 60px 20px; color: rgba(255,255,255,.12); font-size: 13px; letter-spacing: .1em;
-      mat-icon { font-size: 44px; width: 44px; height: 44px; display: block; margin: 0 auto 14px; color: rgba(200,80,60,.15); }
+      mat-icon { font-size: 44px; width: 44px; height: 44px; display: block; margin: 0 auto 14px; color: rgba(200,160,60,.15); }
     }
     @media (max-width: 900px) { .quest-grid { grid-template-columns: 1fr; } }
 
@@ -56,10 +56,10 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     .quest-card {
       position: relative; border-radius: 3px;
       background: rgba(22,20,18,.97);
-      border: 1px solid rgba(200,80,60,.15);
+      border: 1px solid rgba(200,160,60,.15);
       box-shadow: 0 4px 20px rgba(0,0,0,.55);
       transition: border-color .2s, box-shadow .2s;
-      &:hover { border-color: rgba(200,80,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65); }
+      &:hover { border-color: rgba(200,160,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65); }
     }
 
     /* ── Card header ─────────────────────────────── */
@@ -69,12 +69,18 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     .quest-done-icon { font-size: 14px !important; width: 14px !important; height: 14px !important; color: rgba(100,200,100,.8); flex-shrink: 0; }
     .diff-badge {
       font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
-      border-radius: 2px; padding: 4px 10px; cursor: pointer; transition: opacity .15s; white-space: nowrap; flex-shrink: 0;
-      &:hover { opacity: .75; }
-      &--easy     { color: rgba(80,180,100,.8);  background: rgba(60,140,80,.1); border: 1px solid rgba(60,160,80,.3); }
-      &--medium   { color: rgba(200,160,60,.8);  background: rgba(200,160,60,.08); border: 1px solid rgba(200,160,60,.3); }
-      &--hard     { color: rgba(210,110,40,.8);  background: rgba(200,90,30,.1); border: 1px solid rgba(200,90,30,.3); }
-      &--deadly   { color: rgba(220,60,50,.85);  background: rgba(200,40,30,.1); border: 1px solid rgba(200,40,30,.4); }
+      border-radius: 6px; padding: 4px 12px; cursor: pointer; white-space: nowrap; flex-shrink: 0;
+      background: rgba(200,160,60,.08); border: 1px solid rgba(200,160,60,.2); color: #9a8a6a;
+      transition: background .15s, border-color .15s, color .15s;
+      &:hover { background: rgba(200,160,60,.15); border-color: rgba(200,160,60,.4); color: #d4c9a0; }
+      &--easy     { color: rgba(80,180,100,.8);  background: rgba(60,140,80,.08); border-color: rgba(60,160,80,.3);
+        &:hover { background: rgba(60,140,80,.16); border-color: rgba(60,160,80,.5); color: rgba(100,210,120,.9); } }
+      &--medium   { color: rgba(200,160,60,.9);  background: rgba(200,160,60,.08); border-color: rgba(200,160,60,.3);
+        &:hover { background: rgba(200,160,60,.16); border-color: rgba(200,160,60,.55); color: #e8c96a; } }
+      &--hard     { color: rgba(210,130,50,.9);  background: rgba(200,100,30,.08); border-color: rgba(200,110,40,.3);
+        &:hover { background: rgba(200,100,30,.16); border-color: rgba(200,110,40,.55); color: rgba(240,155,70,.9); } }
+      &--deadly   { color: rgba(220,80,60,.9);   background: rgba(200,50,40,.08); border-color: rgba(200,50,40,.3);
+        &:hover { background: rgba(200,50,40,.16); border-color: rgba(200,50,40,.55); color: rgba(255,110,90,.9); } }
     }
     .stage-pips { display: flex; gap: 5px; align-items: center; flex-shrink: 0; }
     .stage-pip {
@@ -83,7 +89,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
       background: rgba(255,255,255,.06);
       transition: background .15s, transform .1s, box-shadow .15s;
       &:hover { transform: scale(1.3); }
-      &--filled { background: rgba(80,140,210,.8); box-shadow: 0 0 6px rgba(80,140,210,.4); border-color: rgba(100,160,230,.6); }
+      &--filled { background: rgba(200,160,60,.8); box-shadow: 0 0 6px rgba(200,160,60,.4); border-color: rgba(220,185,80,.6); }
     }
     .card-header-spacer { flex: 1; min-width: 0; }
     .card-btns { display: flex; flex-shrink: 0; }
@@ -102,11 +108,11 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     .title-row { padding: 0 12px 6px; }
     .title-input {
       width: 100%; box-sizing: border-box; background: transparent; border: none;
-      border-bottom: 1px solid rgba(200,80,60,.2); color: #e8a0a0;
+      border-bottom: 1px solid rgba(200,160,60,.2); color: #e8d8a0;
       font-family: sans-serif; font-size: 14px; letter-spacing: .07em;
       padding: 3px 2px 5px; outline: none; transition: border-color .18s;
-      &::placeholder { color: rgba(200,80,60,.22); }
-      &:focus { border-bottom-color: rgba(200,80,60,.55); }
+      &::placeholder { color: rgba(200,160,60,.22); }
+      &:focus { border-bottom-color: rgba(200,160,60,.55); }
     }
     .card-date { font-size: 9px; color: rgba(255,255,255,.2); letter-spacing: .05em; font-family: sans-serif; margin-top: 4px; }
 
@@ -116,12 +122,12 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     /* ── Meta fields ─────────────────────────────── */
     .meta-row { display: flex; flex-direction: column; gap: 5px; margin-top: 10px; }
     .meta-field { display: flex; align-items: center; gap: 6px; }
-    .meta-icon { font-size: 14px !important; width: 14px !important; height: 14px !important; flex-shrink: 0; color: rgba(200,80,60,.4); }
+    .meta-icon { font-size: 14px !important; width: 14px !important; height: 14px !important; flex-shrink: 0; color: rgba(200,160,60,.4); }
     .meta-input {
       flex: 1; background: transparent; border: none; border-bottom: 1px solid rgba(255,255,255,.06);
       color: #c8b0a8; font-family: sans-serif; font-size: 12px; padding: 2px 2px 3px; outline: none; transition: border-color .15s;
       &::placeholder { color: rgba(255,255,255,.14); font-style: italic; }
-      &:focus { border-bottom-color: rgba(200,80,60,.4); }
+      &:focus { border-bottom-color: rgba(200,160,60,.4); }
     }
 
     /* ── Reward row ──────────────────────────────── */
@@ -136,7 +142,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     /* ── Rich-textarea wrap ──────────────────────── */
     .rt-wrap {
       position: relative; height: 210px; border-radius: 2px; background: rgba(0,0,0,.2);
-      border: 1px solid rgba(200,80,60,.1);
+      border: 1px solid rgba(200,160,60,.1);
       overflow: visible; z-index: 2;
       margin-top: 44px; /* space for floating toolbar */
     }
@@ -259,6 +265,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
                 </div>
 
                 <!-- 🔒 DM-only textarea -->
+                <div class="rt-label">Info pro PH</div>
                 <div class="rt-wrap">
                   <rich-textarea [(ngModel)]="quests()[item.idx].dmNotes" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
                 </div>
@@ -296,9 +303,11 @@ export class DmQuestsComponent {
   readonly store = inject(DmPageStore);
   private readonly auth = inject(AuthService);
 
+  private readonly EXPANDED_STORAGE_KEY = 'dm-quests-expanded-ids';
+
   quests = signal<DmQuestEntry[]>([]);
   filterStatus = signal<FilterStatus>('all');
-  expandedIds = signal<Set<string>>(new Set());
+  expandedIds = signal<Set<string>>(this.loadExpandedIds());
   confirmIdx = signal<number | null>(null);
 
   readonly filterTabs: { value: FilterStatus; label: string }[] = [
@@ -338,6 +347,17 @@ export class DmQuestsComponent {
       const username = this.auth.currentUser()?.username;
       untracked(() => { if (username) this.store.loadDmQuests(username); });
     });
+    effect(() => {
+      const ids = this.expandedIds();
+      try { localStorage.setItem(this.EXPANDED_STORAGE_KEY, JSON.stringify([...ids])); } catch { /* ignore */ }
+    });
+  }
+
+  private loadExpandedIds(): Set<string> {
+    try {
+      const stored = localStorage.getItem('dm-quests-expanded-ids');
+      return stored ? new Set<string>(JSON.parse(stored)) : new Set<string>();
+    } catch { return new Set<string>(); }
   }
 
   addQuest(): void {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -26,7 +26,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
   imports: [FormsModule, MatIcon, MatIconButton, MatTooltip, SpinnerOverlayComponent, RichTextareaComponent],
   host: { '(document:keydown.escape)': 'onEscape()', 'class': 'theme-dark' },
   styles: `
-    :host { display: block; padding: 24px 32px 40px; font-family: sans-serif; overflow: visible; }
+    :host { display: block; padding: 13px 0 20px; font-family: sans-serif; overflow: visible; }
 
     /* ── Buttons ─────────────────────────────────── */
     .btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -30,10 +30,10 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
 
     /* ── Buttons ─────────────────────────────────── */
     .btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
-      border: 1px solid rgba(200,80,60,.35); border-radius: 3px; background: rgba(200,80,60,.08); color: rgba(200,100,80,.8);
+      border: 1px solid rgba(255,255,255,.12); border-radius: 3px; background: rgba(255,255,255,.04); color: rgba(255,255,255,.55);
       padding: 6px 14px; cursor: pointer; display: flex; align-items: center; gap: 5px; transition: background .18s, border-color .18s, color .18s;
       mat-icon { font-size: 15px; width: 15px; height: 15px; }
-      &:hover { background: rgba(200,80,60,.16); border-color: rgba(200,80,60,.6); color: #e8a090; }
+      &:hover { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.25); color: rgba(255,255,255,.85); }
     }
     .btn-icon { padding: 6px 10px; }
     .btn-save { border-color: rgba(80,160,80,.35); color: rgba(100,200,100,.8); background: rgba(60,120,60,.08);
@@ -64,7 +64,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
 
     /* ── Card header ─────────────────────────────── */
     .card-header { display: flex; align-items: center; gap: 6px; padding: 8px 10px 6px; flex-wrap: wrap; cursor: pointer; user-select: none;
-      &:hover { background: rgba(200,80,60,.04); }
+      &:hover { background: rgba(255,255,255,.02); }
     }
     .quest-done-icon { font-size: 14px !important; width: 14px !important; height: 14px !important; color: rgba(100,200,100,.8); flex-shrink: 0; }
     .diff-badge {
@@ -95,7 +95,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
       mat-icon, .mat-icon { font-size: 16px !important; width: 16px !important; height: 16px !important; line-height: 16px !important; display: flex !important; align-items: center !important; justify-content: center !important; }
       .mat-mdc-button-touch-target, .mat-mdc-button-persistent-ripple, .mdc-icon-button__ripple { display: none !important; }
     }
-    .expand-btn { color: rgba(200,80,60,.4) !important; &:hover { color: rgba(200,80,60,.85) !important; background: rgba(200,80,60,.08) !important; } }
+    .expand-btn { color: rgba(255,255,255,.3) !important; &:hover { color: rgba(255,255,255,.7) !important; background: rgba(255,255,255,.06) !important; } }
     .delete-btn { color: rgba(180,60,60,.35) !important; &:hover { color: rgba(220,80,70,.85) !important; background: rgba(180,40,30,.1) !important; } }
 
     /* ── Title ───────────────────────────────────── */

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -58,18 +58,9 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
     }
 
     /* ── Filter + sort bar ───────────────────────── */
-    .filter-bar { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 10px; margin-bottom: 20px; }
-    .filter-tabs { display: flex; gap: 4px; flex-wrap: wrap; }
-    .filter-tab {
-      font-family: sans-serif; font-size: 10px; letter-spacing: .1em; text-transform: uppercase;
-      border: 1px solid rgba(255,255,255,.07); border-radius: 2px; background: transparent;
-      color: rgba(255,255,255,.3); padding: 4px 12px; cursor: pointer;
-      display: flex; align-items: center; gap: 6px; transition: background .15s, border-color .15s, color .15s;
-      &:hover { background: rgba(255,255,255,.05); color: rgba(255,255,255,.55); }
-      &--active { background: rgba(200,80,60,.12); border-color: rgba(200,80,60,.45); color: #e8a090; }
-    }
+    .filter-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
     .filter-count { background: rgba(255,255,255,.08); border-radius: 10px; padding: 0 6px; font-size: 9px; min-width: 18px; text-align: center; line-height: 16px; }
-    .filter-tab--active .filter-count { background: rgba(200,80,60,.2); }
+    .bar-actions { margin-left: auto; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 
     /* ── Grid ────────────────────────────────────── */
     .quest-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 16px; align-items: start; }
@@ -237,7 +228,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
     /* ── Confirm dialog ──────────────────────────── */
     .confirm-backdrop { position: fixed; inset: 0; z-index: 10000; background: rgba(0,0,0,.75); display: flex; align-items: center; justify-content: center; animation: fadeIn .14s ease; }
     .confirm-dialog { position: relative; background: linear-gradient(160deg, rgba(50,20,14,.99) 0%, rgba(30,10,8,1) 100%); border: 1px solid rgba(200,80,60,.35); border-top: 2px solid rgba(200,80,60,.7); box-shadow: 0 12px 50px rgba(0,0,0,.9); border-radius: 3px; padding: 26px 30px 22px; min-width: 300px; max-width: 400px; animation: scaleIn .14s ease;
-      &::before { content: '◆'; position: absolute; top: 7px; left: 9px; font-size: 7px; color: rgba(200,80,60,.35); pointer-events: none; }
     }
     .confirm-icon { display: flex; justify-content: center; margin-bottom: 12px; mat-icon { font-size: 34px; width: 34px; height: 34px; color: rgba(200,80,60,.7); } }
     .confirm-title { font-family: sans-serif; font-size: 13px; letter-spacing: .1em; text-transform: uppercase; color: #e8a090; text-align: center; margin-bottom: 10px; }
@@ -270,13 +260,11 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
     <spinner-overlay [showSpinner]="store.loading()" [diameter]="50">
       <!-- Filter bar + actions in one row -->
       <div class="filter-bar">
-        <div class="filter-tabs">
-          @for (t of filterTabs; track t.value) {
-            <button type="button" class="filter-tab" [class.filter-tab--active]="filterStatus() === t.value" (click)="filterStatus.set(t.value)">
-              {{ t.label }}<span class="filter-count">{{ counts()[t.value] }}</span>
-            </button>
-          }
-        </div>
+        @for (t of filterTabs; track t.value) {
+          <button type="button" class="pt-filter-btn" [class.active]="filterStatus() === t.value" (click)="filterStatus.set(t.value)">
+            {{ t.label }}<span class="filter-count">{{ counts()[t.value] }}</span>
+          </button>
+        }
         <div class="bar-actions">
           <button class="btn btn-icon" type="button" (click)="toggleAllExpanded()"
             [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -302,7 +302,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
                 <div class="reward-row">
                   <mat-icon class="reward-icon" style="color:rgba(200,60,50,.5)">lock</mat-icon>
                   <input class="reward-input reward-input--secret" [(ngModel)]="quests()[item.idx].secretRewards"
-                         placeholder="Tajná/alternativní odměna..." />
+                         placeholder="Tajná / alternativní odměna..." />
                 </div>
               </div>
             }

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -18,7 +18,7 @@ import { DmQuestDifficulty, DmQuestEntry, DmQuestStatus } from '../../dm-page-mo
 
 type FilterStatus = 'all' | DmQuestStatus;
 
-const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuzlení'];
+const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
 
 @Component({
   selector: 'dm-quests',
@@ -57,27 +57,16 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
       position: relative; border-radius: 3px;
       background: rgba(22,20,18,.97);
       border: 1px solid rgba(200,80,60,.15);
-      border-left: 3px solid transparent;
       box-shadow: 0 4px 20px rgba(0,0,0,.55);
       transition: border-color .2s, box-shadow .2s;
       &:hover { border-color: rgba(200,80,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65); }
     }
 
     /* ── Card header ─────────────────────────────── */
-    .card-header { display: flex; align-items: center; gap: 6px; padding: 10px 10px 7px; flex-wrap: wrap; cursor: pointer; user-select: none;
+    .card-header { display: flex; align-items: center; gap: 6px; padding: 8px 10px 6px; flex-wrap: wrap; cursor: pointer; user-select: none;
       &:hover { background: rgba(200,80,60,.04); }
     }
-    .status-badge {
-      font-family: sans-serif; font-size: 10px; letter-spacing: .12em; text-transform: uppercase;
-      border-radius: 10px; padding: 4px 12px; cursor: pointer; border: 1px solid currentColor;
-      transition: filter .15s; white-space: nowrap; flex-shrink: 0;
-      &:hover { filter: brightness(1.2); }
-      &--planned   { color: rgba(100,130,200,.9); background: rgba(80,100,180,.1); }
-      &--active    { color: rgba(80,190,100,.9);  background: rgba(60,160,80,.1); }
-      &--climax    { color: rgba(220,120,40,.9);  background: rgba(200,100,30,.12); }
-      &--completed { color: rgba(200,160,60,.9);  background: rgba(200,160,60,.1); }
-      &--abandoned { color: rgba(120,120,120,.7); background: rgba(100,100,100,.07); }
-    }
+    .quest-done-icon { font-size: 14px !important; width: 14px !important; height: 14px !important; color: rgba(100,200,100,.8); flex-shrink: 0; }
     .diff-badge {
       font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
       border-radius: 2px; padding: 4px 10px; cursor: pointer; transition: filter .15s; white-space: nowrap; flex-shrink: 0;
@@ -147,13 +136,12 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
 
     /* ── Rich-textarea wrap ──────────────────────── */
     .rt-wrap {
-      position: relative; height: 150px; border-radius: 2px; background: rgba(0,0,0,.2);
+      position: relative; height: 210px; border-radius: 2px; background: rgba(0,0,0,.2);
       border: 1px solid rgba(200,80,60,.1);
       overflow: visible; z-index: 2;
       margin-top: 44px; /* space for floating toolbar */
-      & + .rt-wrap { margin-top: 44px; }
     }
-    .rt-wrap--player { border-color: rgba(200,160,60,.12); }
+    .rt-wrap--player { border-color: rgba(200,160,60,.12); margin-top: 10px; }
     .rt-label { font-size: 8px; letter-spacing: .12em; text-transform: uppercase; color: rgba(255,255,255,.2); margin-bottom: 3px; margin-top: 12px; }
 
     /* ── Rich-textarea dark-theme overrides ──────── */
@@ -172,18 +160,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
     :host ::ng-deep .rt-separator { background: rgba(200,160,60,.3) !important; }
     :host ::ng-deep .rt-done-btn { color: rgba(100,200,100,.9) !important;
       &:hover { background: rgba(50,160,50,.15) !important; border-color: rgba(80,180,80,.5) !important; }
-    }
-
-    /* ── Stage bar ───────────────────────────────── */
-    .stage-bar { display: flex; gap: 1px; margin-top: 10px; margin-bottom: 2px; }
-    .stage-seg {
-      flex: 1; height: 18px; cursor: pointer; border: 1px solid rgba(255,255,255,.06);
-      background: rgba(255,255,255,.04); border-radius: 2px;
-      display: flex; align-items: center; justify-content: center;
-      font-family: sans-serif; font-size: 7px; letter-spacing: .06em; color: rgba(255,255,255,.2);
-      text-transform: uppercase; transition: background .15s, color .15s, border-color .15s;
-      &:hover { background: rgba(200,80,60,.12); color: rgba(200,80,60,.8); border-color: rgba(200,80,60,.25); }
-      &--active { background: rgba(200,80,60,.22); border-color: rgba(200,80,60,.5); color: rgba(220,100,80,.9); }
     }
 
     /* ── Confirm dialog ──────────────────────────── */
@@ -228,21 +204,22 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
         }
 
         @for (item of filtered(); track item.quest.id) {
-          <div class="quest-card" [style.border-left-color]="statusColor(item.quest.status)">
+          <div class="quest-card">
 
             <!-- Card header -->
             <div class="card-header" (click)="toggleExpand(item.quest.id)">
-              <button class="status-badge status-badge--{{ item.quest.status }}" type="button"
-                (click)="cycleStatus(item.idx); $event.stopPropagation()" matTooltip="Klikni pro změnu stavu">{{ statusLabel(item.quest.status) }}</button>
               <button class="diff-badge diff-badge--{{ item.quest.difficulty }}" type="button"
                 (click)="cycleDiff(item.idx); $event.stopPropagation()" matTooltip="Obtížnost — klikni pro změnu">{{ diffLabel(item.quest.difficulty) }}</button>
               <!-- Stage pips -->
               <div class="stage-pips">
-                @for (n of [1,2,3,4,5]; track n) {
+                @for (n of [1,2,3,4]; track n) {
                   <span class="stage-pip" [class.stage-pip--filled]="n <= item.quest.stage"
                     (click)="setStage(item.idx, n); $event.stopPropagation()" [matTooltip]="stageName(n)"></span>
                 }
               </div>
+              @if (item.quest.stage >= 4) {
+                <mat-icon class="quest-done-icon" matTooltip="Quest dokončen">task_alt</mat-icon>
+              }
               <span class="card-header-spacer"></span>
               <div class="card-btns">
                 <button mat-icon-button class="expand-btn" type="button"
@@ -254,19 +231,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
                 </button>
               </div>
             </div>
-
-            <!-- Stage progress bar -->
-            @if (expandedIds().has(item.quest.id)) {
-              <div class="expanded-body" style="padding-top:4px">
-                <div class="stage-bar">
-                  @for (n of [1,2,3,4,5]; track n) {
-                    <div class="stage-seg" [class.stage-seg--active]="n <= item.quest.stage" (click)="setStage(item.idx, n)">
-                      {{ stageName(n) }}
-                    </div>
-                  }
-                </div>
-              </div>
-            }
 
             <!-- Title -->
             <div class="title-row">
@@ -282,8 +246,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
                 <div class="meta-row">
                   <div class="meta-field"><mat-icon class="meta-icon">place</mat-icon>
                     <input class="meta-input" [(ngModel)]="quests()[item.idx].location" placeholder="Lokalita / Oblast" /></div>
-                  <div class="meta-field"><mat-icon class="meta-icon">group</mat-icon>
-                    <input class="meta-input" [(ngModel)]="quests()[item.idx].partyMembers" placeholder="Členové skupiny (čárkami)" /></div>
                   <div class="meta-field"><mat-icon class="meta-icon" style="color:rgba(200,60,50,.45)">whatshot</mat-icon>
                     <input class="meta-input" [(ngModel)]="quests()[item.idx].antagonist" placeholder="Antagonista / Padouch" /></div>
                 </div>
@@ -404,16 +366,12 @@ export class DmQuestsComponent {
   expandAll(): void { this.expandedIds.set(new Set(this.quests().map(q => q.id))); }
   collapseAll(): void { this.expandedIds.set(new Set()); }
 
-  cycleStatus(idx: number): void {
-    const order: DmQuestStatus[] = ['planned', 'active', 'climax', 'completed', 'abandoned'];
-    this.quests.update(list => list.map((q, i) => i !== idx ? q : { ...q, status: order[(order.indexOf(q.status) + 1) % order.length] }));
-  }
   cycleDiff(idx: number): void {
     const order: DmQuestDifficulty[] = ['trivial', 'easy', 'medium', 'hard', 'deadly'];
     this.quests.update(list => list.map((q, i) => i !== idx ? q : { ...q, difficulty: order[(order.indexOf(q.difficulty) + 1) % order.length] }));
   }
   setStage(idx: number, stage: number): void {
-    this.quests.update(list => list.map((q, i) => i !== idx ? q : { ...q, stage }));
+    this.quests.update(list => list.map((q, i) => i !== idx ? q : { ...q, stage: q.stage === stage ? stage - 1 : stage }));
   }
 
   askDelete(idx: number): void { this.confirmIdx.set(idx); }
@@ -436,17 +394,9 @@ export class DmQuestsComponent {
   onEscape(): void { if (this.confirmIdx() !== null) this.cancelDelete(); }
 
   // ── Labels / colours ─────────────────────────────────────────────────────
-  statusLabel(s: DmQuestStatus): string {
-    const map: Record<DmQuestStatus, string> = { planned: 'Naplánováno', active: 'Aktivní', climax: 'Vyvrcholení', completed: 'Dokončeno', abandoned: 'Opuštěno' };
-    return map[s];
-  }
   diffLabel(d: DmQuestDifficulty): string {
     const map: Record<DmQuestDifficulty, string> = { trivial: 'Trivální', easy: 'Lehké', medium: 'Střední', hard: 'Těžké', deadly: 'Smrtelné' };
     return map[d];
-  }
-  statusColor(s: DmQuestStatus): string {
-    const map: Record<DmQuestStatus, string> = { planned: 'rgba(100,130,200,.8)', active: 'rgba(80,190,100,.8)', climax: 'rgba(220,120,40,.9)', completed: 'rgba(200,160,60,.85)', abandoned: 'rgba(80,80,80,.5)' };
-    return map[s];
   }
   stageName(n: number): string { return STAGE_LABELS[n - 1] ?? ''; }
 }

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -27,23 +27,9 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
   selector: 'dm-quests',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormsModule, MatIcon, MatIconButton, MatTooltip, SpinnerOverlayComponent, RichTextareaComponent],
-  host: { '(document:keydown.escape)': 'onEscape()' },
+  host: { '(document:keydown.escape)': 'onEscape()', 'class': 'theme-dark' },
   styles: `
     :host { display: block; padding: 24px 32px 40px; font-family: sans-serif; overflow: visible; }
-
-    /* ── Header ─────────────────────────────────── */
-    .header {
-      display: flex; align-items: flex-start; justify-content: space-between;
-      flex-wrap: wrap; gap: 14px; margin-bottom: 20px; padding-bottom: 14px;
-      border-bottom: 2px solid transparent;
-      border-image: linear-gradient(90deg, transparent, rgba(180,30,30,.6) 20%, rgba(220,60,50,.8) 50%, rgba(180,30,30,.6) 80%, transparent) 1;
-    }
-    .header-title { font-size: 22px; letter-spacing: .12em; text-transform: uppercase; color: #e8a0a0;
-      text-shadow: 0 0 18px rgba(200,60,50,.4); display: flex; align-items: center; gap: 10px;
-      mat-icon { font-size: 26px; width: 26px; height: 26px; color: #c05040; }
-    }
-    .header-subtitle { font-size: 11px; color: rgba(200,80,70,.4); letter-spacing: .05em; margin-top: 5px; font-family: sans-serif; font-style: italic; text-transform: none; }
-    .header-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 
     /* ── Buttons ─────────────────────────────────── */
     .btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
@@ -63,10 +49,11 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
     .bar-actions { margin-left: auto; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 
     /* ── Grid ────────────────────────────────────── */
-    .quest-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 16px; align-items: start; }
+    .quest-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; align-items: start; }
     .empty-state { grid-column: 1 / -1; text-align: center; padding: 60px 20px; color: rgba(255,255,255,.12); font-size: 13px; letter-spacing: .1em;
       mat-icon { font-size: 44px; width: 44px; height: 44px; display: block; margin: 0 auto 14px; color: rgba(200,80,60,.15); }
     }
+    @media (max-width: 900px) { .quest-grid { grid-template-columns: 1fr; } }
 
     /* ── Card ────────────────────────────────────── */
     .quest-card {
@@ -75,17 +62,19 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
       border: 1px solid rgba(200,80,60,.15);
       border-left: 3px solid transparent;
       box-shadow: 0 4px 20px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,120,100,.03);
-      transition: border-color .2s, box-shadow .2s; overflow: hidden;
+      transition: border-color .2s, box-shadow .2s;
       &::before { content: '◆'; position: absolute; top: 5px; left: 8px; font-size: 6px; color: rgba(200,80,60,.2); pointer-events: none; }
       &:hover { border-color: rgba(200,80,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65), 0 0 10px rgba(200,80,60,.05); }
     }
     .quest-card-rule { height: 2px; background: linear-gradient(90deg, rgba(200,80,60,.0) 0%, rgba(200,80,60,.4) 30%, rgba(240,100,80,.6) 50%, rgba(200,80,60,.4) 70%, rgba(200,80,60,.0) 100%); }
 
     /* ── Card header ─────────────────────────────── */
-    .card-header { display: flex; align-items: center; gap: 6px; padding: 8px 10px 5px; flex-wrap: wrap; }
+    .card-header { display: flex; align-items: center; gap: 6px; padding: 10px 10px 7px; flex-wrap: wrap; cursor: pointer; user-select: none;
+      &:hover { background: rgba(200,80,60,.04); }
+    }
     .status-badge {
-      font-family: sans-serif; font-size: 8px; letter-spacing: .12em; text-transform: uppercase;
-      border-radius: 10px; padding: 2px 9px; cursor: pointer; border: 1px solid currentColor;
+      font-family: sans-serif; font-size: 10px; letter-spacing: .12em; text-transform: uppercase;
+      border-radius: 10px; padding: 4px 12px; cursor: pointer; border: 1px solid currentColor;
       transition: filter .15s; white-space: nowrap; flex-shrink: 0;
       &:hover { filter: brightness(1.2); }
       &--planned   { color: rgba(100,130,200,.9); background: rgba(80,100,180,.1); }
@@ -95,8 +84,8 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
       &--abandoned { color: rgba(120,120,120,.7); background: rgba(100,100,100,.07); }
     }
     .diff-badge {
-      font-family: sans-serif; font-size: 7px; letter-spacing: .1em; text-transform: uppercase;
-      border-radius: 2px; padding: 2px 7px; cursor: pointer; transition: filter .15s; white-space: nowrap; flex-shrink: 0;
+      font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
+      border-radius: 2px; padding: 4px 10px; cursor: pointer; transition: filter .15s; white-space: nowrap; flex-shrink: 0;
       &:hover { filter: brightness(1.2); }
       &--trivial  { color: rgba(120,200,120,.8); background: rgba(80,160,80,.1); border: 1px solid rgba(80,160,80,.3); }
       &--easy     { color: rgba(80,180,100,.8);  background: rgba(60,140,80,.1); border: 1px solid rgba(60,160,80,.3); }
@@ -104,29 +93,29 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
       &--hard     { color: rgba(210,110,40,.8);  background: rgba(200,90,30,.1); border: 1px solid rgba(200,90,30,.3); }
       &--deadly   { color: rgba(220,60,50,.85);  background: rgba(200,40,30,.1); border: 1px solid rgba(200,40,30,.4); }
     }
-    .stage-pips { display: flex; gap: 3px; align-items: center; flex-shrink: 0; }
+    .stage-pips { display: flex; gap: 5px; align-items: center; flex-shrink: 0; }
     .stage-pip {
-      width: 8px; height: 8px; border-radius: 50%; cursor: pointer;
+      width: 16px; height: 16px; border-radius: 50%; cursor: pointer;
       border: 1px solid rgba(255,255,255,.15);
       background: rgba(255,255,255,.06);
       transition: background .15s, transform .1s, box-shadow .15s;
       &:hover { transform: scale(1.3); }
-      &--filled { background: rgba(200,80,60,.8); box-shadow: 0 0 5px rgba(200,80,60,.5); border-color: rgba(200,80,60,.6); }
+      &--filled { background: rgba(200,80,60,.8); box-shadow: 0 0 6px rgba(200,80,60,.5); border-color: rgba(200,80,60,.6); }
     }
-    .card-date { font-size: 9px; color: rgba(255,255,255,.2); letter-spacing: .05em; font-family: sans-serif; flex: 1; text-align: right; }
+    .card-header-spacer { flex: 1; min-width: 0; }
     .card-btns { display: flex; flex-shrink: 0; }
     .expand-btn, .delete-btn {
-      width: 26px !important; height: 26px !important; padding: 0 !important;
+      width: 44px !important; height: 44px !important; padding: 0 !important;
       display: inline-flex !important; align-items: center !important; justify-content: center !important;
-      border-radius: 2px !important; transition: color .15s, background .15s !important;
-      mat-icon, .mat-icon { font-size: 16px !important; width: 16px !important; height: 16px !important; display: flex !important; align-items: center !important; justify-content: center !important; }
+      border-radius: 3px !important; transition: color .15s, background .15s !important;
+      mat-icon, .mat-icon { font-size: 24px !important; width: 24px !important; height: 24px !important; display: flex !important; align-items: center !important; justify-content: center !important; }
       .mat-mdc-button-touch-target, .mat-mdc-button-persistent-ripple, .mdc-icon-button__ripple { display: none !important; }
     }
     .expand-btn { color: rgba(200,80,60,.4) !important; &:hover { color: rgba(200,80,60,.85) !important; background: rgba(200,80,60,.08) !important; } }
     .delete-btn { color: rgba(180,60,60,.35) !important; &:hover { color: rgba(220,80,70,.85) !important; background: rgba(180,40,30,.1) !important; } }
 
     /* ── Title ───────────────────────────────────── */
-    .title-row { padding: 0 12px 10px; }
+    .title-row { padding: 0 12px 6px; }
     .title-input {
       width: 100%; box-sizing: border-box; background: transparent; border: none;
       border-bottom: 1px solid rgba(200,80,60,.2); color: #e8a0a0;
@@ -135,6 +124,7 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
       &::placeholder { color: rgba(200,80,60,.22); }
       &:focus { border-bottom-color: rgba(200,80,60,.55); }
     }
+    .card-date { font-size: 9px; color: rgba(255,255,255,.2); letter-spacing: .05em; font-family: sans-serif; margin-top: 4px; }
 
     /* ── Expanded body ───────────────────────────── */
     .expanded-body { padding: 0 12px 14px; }
@@ -177,25 +167,6 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
       &:focus { border-bottom-color: rgba(200,80,60,.4); }
     }
 
-    /* ── Player-visible section ──────────────────── */
-    .section-player {
-      margin-top: 12px; border: 1px solid rgba(200,160,60,.18); border-radius: 3px; overflow: hidden;
-      .section-label { display: flex; align-items: center; gap: 6px; padding: 6px 10px; background: rgba(200,160,60,.06); font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: rgba(200,160,60,.7); border-bottom: 1px solid rgba(200,160,60,.12);
-        mat-icon { font-size: 13px; width: 13px; height: 13px; color: rgba(200,160,60,.6); }
-      }
-      .section-body { padding: 8px 10px; }
-    }
-
-    /* ── DM-only secret section ──────────────────── */
-    .section-dm {
-      margin-top: 10px; border: 1px solid rgba(180,30,30,.3); border-radius: 3px; overflow: hidden;
-      background: rgba(60,10,10,.3);
-      .section-label { display: flex; align-items: center; gap: 6px; padding: 6px 10px; background: rgba(180,30,30,.15); font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: rgba(220,80,70,.75); border-bottom: 1px solid rgba(180,30,30,.2);
-        mat-icon { font-size: 13px; width: 13px; height: 13px; color: rgba(220,80,70,.7); }
-      }
-      .section-body { padding: 8px 10px; }
-    }
-
     /* ── Reward row ──────────────────────────────── */
     .reward-row { display: flex; align-items: center; gap: 6px; margin-top: 8px; }
     .reward-icon { font-size: 13px !important; width: 13px !important; height: 13px !important; flex-shrink: 0; }
@@ -206,12 +177,39 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
     .reward-input--secret { color: rgba(220,80,70,.7); &:focus { border-bottom-color: rgba(200,50,40,.4); } }
 
     /* ── Rich-textarea wrap ──────────────────────── */
-    .rt-wrap { position: relative; height: 130px; border-radius: 2px; background: rgba(0,0,0,.2); overflow: hidden;
+    .rt-wrap {
+      position: relative; height: 150px; border-radius: 2px; background: rgba(0,0,0,.2);
       border: 1px solid rgba(200,80,60,.1);
-      & + .rt-wrap { margin-top: 6px; }
+      overflow: visible; z-index: 2;
+      margin-top: 44px; /* space for floating toolbar */
+      & + .rt-wrap { margin-top: 44px; }
     }
     .rt-wrap--player { border-color: rgba(200,160,60,.12); }
-    .rt-label { font-size: 8px; letter-spacing: .12em; text-transform: uppercase; color: rgba(255,255,255,.2); margin-bottom: 3px; }
+    .rt-label { font-size: 8px; letter-spacing: .12em; text-transform: uppercase; color: rgba(255,255,255,.2); margin-bottom: 3px; margin-top: 12px; }
+
+    /* ── Rich-textarea dark-theme overrides ──────── */
+    :host ::ng-deep .rt-toolbar {
+      background: rgba(22,14,6,.97) !important;
+      border-color: rgba(200,160,60,.35) !important;
+      box-shadow: 0 2px 12px rgba(0,0,0,.6) !important;
+      button { color: rgba(220,195,130,.9) !important;
+        &:hover { background: rgba(200,160,60,.14) !important; border-color: rgba(200,160,60,.45) !important; color: #e8c96a !important; }
+      }
+    }
+    :host ::ng-deep .rt-toolbar--inline {
+      background: rgba(18,12,5,.98) !important;
+      border-color: rgba(200,160,60,.25) !important;
+    }
+    :host ::ng-deep .rt-separator { background: rgba(200,160,60,.3) !important; }
+    :host ::ng-deep .rt-done-btn { color: rgba(100,200,100,.9) !important;
+      &:hover { background: rgba(50,160,50,.15) !important; border-color: rgba(80,180,80,.5) !important; }
+    }
+
+    /* ── Collapsed image thumbnail ───────────────── */
+    .collapsed-thumb {
+      height: 70px; overflow: hidden; border-top: 1px solid rgba(200,80,60,.1);
+      img { width: 100%; height: 100%; object-fit: cover; opacity: 0.65; display: block; }
+    }
 
     /* ── Stage bar ───────────────────────────────── */
     .stage-bar { display: flex; gap: 1px; margin-top: 10px; margin-bottom: 2px; }
@@ -286,25 +284,25 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
             <div class="quest-card-rule"></div>
 
             <!-- Card header -->
-            <div class="card-header">
+            <div class="card-header" (click)="toggleExpand(item.quest.id)">
               <button class="status-badge status-badge--{{ item.quest.status }}" type="button"
-                (click)="cycleStatus(item.idx)" matTooltip="Klikni pro změnu stavu">{{ statusLabel(item.quest.status) }}</button>
+                (click)="cycleStatus(item.idx); $event.stopPropagation()" matTooltip="Klikni pro změnu stavu">{{ statusLabel(item.quest.status) }}</button>
               <button class="diff-badge diff-badge--{{ item.quest.difficulty }}" type="button"
-                (click)="cycleDiff(item.idx)" matTooltip="Obtížnost — klikni pro změnu">{{ diffLabel(item.quest.difficulty) }}</button>
+                (click)="cycleDiff(item.idx); $event.stopPropagation()" matTooltip="Obtížnost — klikni pro změnu">{{ diffLabel(item.quest.difficulty) }}</button>
               <!-- Stage pips -->
               <div class="stage-pips">
                 @for (n of [1,2,3,4,5]; track n) {
                   <span class="stage-pip" [class.stage-pip--filled]="n <= item.quest.stage"
-                    (click)="setStage(item.idx, n)" [matTooltip]="stageName(n)"></span>
+                    (click)="setStage(item.idx, n); $event.stopPropagation()" [matTooltip]="stageName(n)"></span>
                 }
               </div>
-              <span class="card-date">{{ item.quest.dateAdded }}</span>
+              <span class="card-header-spacer"></span>
               <div class="card-btns">
-                <button mat-icon-button class="expand-btn" type="button" (click)="toggleExpand(item.quest.id)"
+                <button mat-icon-button class="expand-btn" type="button"
                   [matTooltip]="expandedIds().has(item.quest.id) ? 'Sbalit' : 'Rozbalit'">
                   <mat-icon>{{ expandedIds().has(item.quest.id) ? 'expand_less' : 'expand_more' }}</mat-icon>
                 </button>
-                <button mat-icon-button class="delete-btn" type="button" (click)="askDelete(item.idx)" matTooltip="Smazat">
+                <button mat-icon-button class="delete-btn" type="button" (click)="askDelete(item.idx); $event.stopPropagation()" matTooltip="Smazat">
                   <mat-icon>delete_outline</mat-icon>
                 </button>
               </div>
@@ -325,8 +323,18 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
 
             <!-- Title -->
             <div class="title-row">
-              <input class="title-input" [(ngModel)]="quests()[item.idx].title" placeholder="Název questu / příběhu..." />
+              <input class="title-input" [(ngModel)]="quests()[item.idx].title" placeholder="Název questu / příběhu..." (click)="$event.stopPropagation()" />
+              @if (item.quest.dateAdded) {
+                <div class="card-date">{{ item.quest.dateAdded }}</div>
+              }
             </div>
+
+            <!-- Collapsed image preview -->
+            @if (!expandedIds().has(item.quest.id) && quests()[item.idx].imageBase64) {
+              <div class="collapsed-thumb">
+                <img [src]="'data:image/png;base64,' + quests()[item.idx].imageBase64" [alt]="quests()[item.idx].title" />
+              </div>
+            }
 
             @if (expandedIds().has(item.quest.id)) {
               <div class="expanded-body">
@@ -356,38 +364,22 @@ const STAGE_LABELS = ['Zahájení', 'Rozvoj', 'Konflikt', 'Vyvrcholení', 'Rozuz
                     <input class="meta-input" [(ngModel)]="quests()[item.idx].antagonist" placeholder="Antagonista / Padouch" /></div>
                 </div>
 
-                <!-- ⚔ Player-visible section -->
-                <div class="section-player">
-                  <div class="section-label"><mat-icon>groups</mat-icon>CO VĚDÍ HRÁČI</div>
-                  <div class="section-body">
-                    <div class="rt-label">Popis pro hráče</div>
-                    <div class="rt-wrap rt-wrap--player">
-                      <rich-textarea [(ngModel)]="quests()[item.idx].playerDescription" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
-                    </div>
-                    <div class="reward-row">
-                      <mat-icon class="reward-icon" style="color:rgba(200,160,60,.55)">payments</mat-icon>
-                      <input class="reward-input" [(ngModel)]="quests()[item.idx].publicRewards" placeholder="Veřejná odměna (hráči to ví)..." />
-                    </div>
-                  </div>
+                <!-- ⚔ Player-visible textarea -->
+                <div class="rt-wrap rt-wrap--player">
+                  <rich-textarea [(ngModel)]="quests()[item.idx].playerDescription" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
+                </div>
+                <div class="reward-row">
+                  <mat-icon class="reward-icon" style="color:rgba(200,160,60,.55)">payments</mat-icon>
+                  <input class="reward-input" [(ngModel)]="quests()[item.idx].publicRewards" placeholder="Veřejná odměna (hráči to ví)..." />
                 </div>
 
-                <!-- 🔒 DM-only section -->
-                <div class="section-dm">
-                  <div class="section-label"><mat-icon>lock</mat-icon>POUZE PH — TAJNÉ POZNÁMKY</div>
-                  <div class="section-body">
-                    <div class="rt-label">DM poznámky &amp; plány</div>
-                    <div class="rt-wrap">
-                      <rich-textarea [(ngModel)]="quests()[item.idx].dmNotes" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
-                    </div>
-                    <div class="rt-label" style="margin-top:8px">Story hooks &amp; vodítka</div>
-                    <div class="rt-wrap">
-                      <rich-textarea [(ngModel)]="quests()[item.idx].storyHooks" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
-                    </div>
-                    <div class="reward-row">
-                      <mat-icon class="reward-icon" style="color:rgba(200,60,50,.5)">lock</mat-icon>
-                      <input class="reward-input reward-input--secret" [(ngModel)]="quests()[item.idx].secretRewards" placeholder="Tajná odměna / DM plán..." />
-                    </div>
-                  </div>
+                <!-- 🔒 DM-only textarea -->
+                <div class="rt-wrap">
+                  <rich-textarea [(ngModel)]="quests()[item.idx].dmNotes" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
+                </div>
+                <div class="reward-row">
+                  <mat-icon class="reward-icon" style="color:rgba(200,60,50,.5)">lock</mat-icon>
+                  <input class="reward-input reward-input--secret" [(ngModel)]="quests()[item.idx].secretRewards" placeholder="Tajná odměna / DM plán..." />
                 </div>
               </div>
             }

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -315,9 +315,10 @@ export class DmQuestsComponent {
   private readonly auth = inject(AuthService);
 
   private readonly EXPANDED_STORAGE_KEY = 'dm-quests-expanded-ids';
+  private readonly FILTER_STORAGE_KEY = 'dm-quests-filter';
 
   quests = signal<DmQuestEntry[]>([]);
-  filterStatus = signal<FilterStatus>('all');
+  filterStatus = signal<FilterStatus>(this.loadFilterStatus());
   expandedIds = signal<Set<string>>(this.loadExpandedIds());
   confirmIdx = signal<number | null>(null);
 
@@ -333,10 +334,10 @@ export class DmQuestsComponent {
     const all = this.quests();
     return {
       all: all.length,
-      planned: all.filter(q => q.status === 'planned').length,
-      active: all.filter(q => q.status === 'active').length,
-      climax: all.filter(q => q.status === 'climax').length,
-      completed: all.filter(q => q.status === 'completed').length,
+      planned: all.filter(q => (q.stage ?? 0) <= 1).length,
+      active: all.filter(q => q.stage === 2).length,
+      climax: all.filter(q => q.stage === 3).length,
+      completed: all.filter(q => q.stage >= 4).length,
     };
   });
 
@@ -344,7 +345,15 @@ export class DmQuestsComponent {
     const fs = this.filterStatus();
     return this.quests()
       .map((quest, idx) => ({ quest, idx }))
-      .filter(({ quest }) => fs === 'all' || quest.status === fs);
+      .filter(({ quest }) => {
+        if (fs === 'all') return true;
+        const s = quest.stage ?? 0;
+        if (fs === 'planned')   return s <= 1;
+        if (fs === 'active')    return s === 2;
+        if (fs === 'climax')    return s === 3;
+        if (fs === 'completed') return s >= 4;
+        return true;
+      });
   });
 
   constructor() {
@@ -360,6 +369,10 @@ export class DmQuestsComponent {
       const ids = this.expandedIds();
       try { localStorage.setItem(this.EXPANDED_STORAGE_KEY, JSON.stringify([...ids])); } catch { /* ignore */ }
     });
+    effect(() => {
+      const fs = this.filterStatus();
+      try { localStorage.setItem(this.FILTER_STORAGE_KEY, fs); } catch { /* ignore */ }
+    });
   }
 
   private loadExpandedIds(): Set<string> {
@@ -367,6 +380,14 @@ export class DmQuestsComponent {
       const stored = localStorage.getItem('dm-quests-expanded-ids');
       return stored ? new Set<string>(JSON.parse(stored)) : new Set<string>();
     } catch { return new Set<string>(); }
+  }
+
+  private loadFilterStatus(): FilterStatus {
+    const valid: FilterStatus[] = ['all', 'planned', 'active', 'climax', 'completed'];
+    try {
+      const stored = localStorage.getItem('dm-quests-filter') as FilterStatus;
+      return valid.includes(stored) ? stored : 'all';
+    } catch { return 'all'; }
   }
 
   addQuest(): void {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -16,7 +16,7 @@ import { AuthService } from '@dn-d-servant/util';
 import { DmPageStore } from '../../dm-page.store';
 import { DmQuestDifficulty, DmQuestEntry, DmQuestStatus } from '../../dm-page-models';
 
-type FilterStatus = 'all' | DmQuestStatus;
+type FilterStatus = 'all' | 'planned' | 'active' | 'climax' | 'completed';
 
 const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
 
@@ -42,7 +42,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
 
     /* ── Filter + sort bar ───────────────────────── */
     .filter-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
-    .filter-count { background: rgba(255,255,255,.08); border-radius: 10px; padding: 0 6px; font-size: 9px; min-width: 18px; text-align: center; line-height: 16px; }
+    .filter-count { background: rgba(255,255,255,.08); border-radius: 10px; padding: 0 6px; font-size: 9px; min-width: 18px; text-align: center; line-height: 16px; margin-left: 6px; }
     .bar-actions { margin-left: auto; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 
     /* ── Grid ────────────────────────────────────── */
@@ -109,12 +109,22 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     .title-input {
       width: 100%; box-sizing: border-box; background: transparent; border: none;
       border-bottom: 1px solid rgba(200,160,60,.2); color: #e8d8a0;
-      font-family: sans-serif; font-size: 14px; letter-spacing: .07em;
+      font-family: sans-serif; font-size: 15px; letter-spacing: .07em;
       padding: 3px 2px 5px; outline: none; transition: border-color .18s;
       &::placeholder { color: rgba(200,160,60,.22); }
       &:focus { border-bottom-color: rgba(200,160,60,.55); }
     }
-    .card-date { font-size: 9px; color: rgba(255,255,255,.2); letter-spacing: .05em; font-family: sans-serif; margin-top: 4px; }
+    .card-meta-peek { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-top: 5px; }
+    .card-date { font-size: 10px; color: rgba(255,255,255,.2); letter-spacing: .05em; font-family: sans-serif; flex-shrink: 0; }
+    .peek-sep { color: rgba(255,255,255,.1); font-size: 10px; flex-shrink: 0; }
+    .peek-icon { font-size: 12px !important; width: 12px !important; height: 12px !important; flex-shrink: 0; color: rgba(200,160,60,.35); }
+    .peek-input {
+      background: transparent; border: none; border-bottom: 1px solid transparent;
+      color: rgba(200,185,140,.55); font-family: sans-serif; font-size: 13px;
+      padding: 1px 2px 2px; outline: none; min-width: 60px; max-width: 120px; transition: border-color .15s, color .15s;
+      &::placeholder { color: rgba(255,255,255,.1); font-style: italic; }
+      &:focus { border-bottom-color: rgba(200,160,60,.3); color: rgba(220,200,150,.8); }
+    }
 
     /* ── Expanded body ───────────────────────────── */
     .expanded-body { padding: 0 12px 14px; }
@@ -125,7 +135,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     .meta-icon { font-size: 14px !important; width: 14px !important; height: 14px !important; flex-shrink: 0; color: rgba(200,160,60,.4); }
     .meta-input {
       flex: 1; background: transparent; border: none; border-bottom: 1px solid rgba(255,255,255,.06);
-      color: #c8b0a8; font-family: sans-serif; font-size: 12px; padding: 2px 2px 3px; outline: none; transition: border-color .15s;
+      color: #c8b0a8; font-family: sans-serif; font-size: 13px; padding: 2px 2px 3px; outline: none; transition: border-color .15s;
       &::placeholder { color: rgba(255,255,255,.14); font-style: italic; }
       &:focus { border-bottom-color: rgba(200,160,60,.4); }
     }
@@ -240,20 +250,21 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
             <!-- Title -->
             <div class="title-row">
               <input class="title-input" [(ngModel)]="quests()[item.idx].title" placeholder="Název questu / příběhu..." (click)="$event.stopPropagation()" />
-              @if (item.quest.dateAdded) {
-                <div class="card-date">{{ item.quest.dateAdded }}</div>
-              }
+              <div class="card-meta-peek">
+                @if (item.quest.dateAdded) {
+                  <span class="card-date">{{ item.quest.dateAdded }}</span>
+                  <span class="peek-sep">·</span>
+                }
+                <mat-icon class="peek-icon">place</mat-icon>
+                <input class="peek-input" [(ngModel)]="quests()[item.idx].location" placeholder="Lokalita..." (click)="$event.stopPropagation()" />
+                <span class="peek-sep">·</span>
+                <mat-icon class="peek-icon" style="color:rgba(200,80,60,.35)">whatshot</mat-icon>
+                <input class="peek-input" [(ngModel)]="quests()[item.idx].antagonist" placeholder="Antagonista..." (click)="$event.stopPropagation()" />
+              </div>
             </div>
 
             @if (expandedIds().has(item.quest.id)) {
               <div class="expanded-body">
-                <!-- Meta -->
-                <div class="meta-row">
-                  <div class="meta-field"><mat-icon class="meta-icon">place</mat-icon>
-                    <input class="meta-input" [(ngModel)]="quests()[item.idx].location" placeholder="Lokalita / Oblast" /></div>
-                  <div class="meta-field"><mat-icon class="meta-icon" style="color:rgba(200,60,50,.45)">whatshot</mat-icon>
-                    <input class="meta-input" [(ngModel)]="quests()[item.idx].antagonist" placeholder="Antagonista / Padouch" /></div>
-                </div>
 
                 <!-- ⚔ Player-visible textarea -->
                 <div class="rt-wrap rt-wrap--player">
@@ -312,11 +323,10 @@ export class DmQuestsComponent {
 
   readonly filterTabs: { value: FilterStatus; label: string }[] = [
     { value: 'all', label: 'Vše' },
-    { value: 'planned', label: 'Naplánováno' },
+    { value: 'planned', label: 'Neaktivní' },
     { value: 'active', label: 'Aktivní' },
-    { value: 'climax', label: 'Vyvrcholení' },
+    { value: 'climax', label: 'Rozuzlení' },
     { value: 'completed', label: 'Dokončeno' },
-    { value: 'abandoned', label: 'Opuštěno' },
   ];
 
   readonly counts = computed((): Record<FilterStatus, number> => {
@@ -327,7 +337,6 @@ export class DmQuestsComponent {
       active: all.filter(q => q.status === 'active').length,
       climax: all.filter(q => q.status === 'climax').length,
       completed: all.filter(q => q.status === 'completed').length,
-      abandoned: all.filter(q => q.status === 'abandoned').length,
     };
   });
 

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -28,17 +28,6 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
   styles: `
     :host { display: block; padding: 13px 0 20px; font-family: sans-serif; overflow: visible; }
 
-    /* ── Buttons ─────────────────────────────────── */
-    .btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
-      border: 1px solid rgba(255,255,255,.12); border-radius: 3px; background: rgba(255,255,255,.04); color: rgba(255,255,255,.55);
-      padding: 6px 14px; cursor: pointer; display: flex; align-items: center; gap: 5px; transition: background .18s, border-color .18s, color .18s;
-      mat-icon { font-size: 15px; width: 15px; height: 15px; }
-      &:hover { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.25); color: rgba(255,255,255,.85); }
-    }
-    .btn-icon { padding: 6px 10px; }
-    .btn-save { border-color: rgba(80,160,80,.35); color: rgba(100,200,100,.8); background: rgba(60,120,60,.08);
-      &:hover { background: rgba(60,140,60,.18); border-color: rgba(80,180,80,.6); color: #80e080; }
-    }
 
     /* ── Filter + sort bar ───────────────────────── */
     .filter-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
@@ -204,15 +193,15 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
           </button>
         }
         <div class="bar-actions">
-          <button class="btn btn-icon" type="button" (click)="toggleAllExpanded()"
+          <button class="pt-filter-btn" type="button" (click)="toggleAllExpanded()"
                   [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozvinout vše'">
             <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
           </button>
-          <button class="btn" type="button" (click)="addQuest()">
+          <button class="pt-filter-btn" type="button" (click)="addQuest()">
             <mat-icon>add</mat-icon>
             Přidat quest
           </button>
-          <button class="btn btn-save" type="button" (click)="save()">
+          <button class="pt-filter-btn" type="button" (click)="save()">
             <mat-icon>save</mat-icon>
             Uložit
           </button>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -83,7 +83,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
       background: rgba(255,255,255,.06);
       transition: background .15s, transform .1s, box-shadow .15s;
       &:hover { transform: scale(1.3); }
-      &--filled { background: rgba(200,80,60,.8); box-shadow: 0 0 6px rgba(200,80,60,.5); border-color: rgba(200,80,60,.6); }
+      &--filled { background: rgba(80,140,210,.8); box-shadow: 0 0 6px rgba(80,140,210,.4); border-color: rgba(100,160,230,.6); }
     }
     .card-header-spacer { flex: 1; min-width: 0; }
     .card-btns { display: flex; flex-shrink: 0; }

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-quests/dm-quests.component.ts
@@ -69,9 +69,8 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
     .quest-done-icon { font-size: 14px !important; width: 14px !important; height: 14px !important; color: rgba(100,200,100,.8); flex-shrink: 0; }
     .diff-badge {
       font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
-      border-radius: 2px; padding: 4px 10px; cursor: pointer; transition: filter .15s; white-space: nowrap; flex-shrink: 0;
-      &:hover { filter: brightness(1.2); }
-      &--trivial  { color: rgba(120,200,120,.8); background: rgba(80,160,80,.1); border: 1px solid rgba(80,160,80,.3); }
+      border-radius: 2px; padding: 4px 10px; cursor: pointer; transition: opacity .15s; white-space: nowrap; flex-shrink: 0;
+      &:hover { opacity: .75; }
       &--easy     { color: rgba(80,180,100,.8);  background: rgba(60,140,80,.1); border: 1px solid rgba(60,160,80,.3); }
       &--medium   { color: rgba(200,160,60,.8);  background: rgba(200,160,60,.08); border: 1px solid rgba(200,160,60,.3); }
       &--hard     { color: rgba(210,110,40,.8);  background: rgba(200,90,30,.1); border: 1px solid rgba(200,90,30,.3); }
@@ -209,7 +208,7 @@ const STAGE_LABELS = ['Neaktivní', 'Aktivní', 'Rozuzlení', 'Dokončeno'];
             <!-- Card header -->
             <div class="card-header" (click)="toggleExpand(item.quest.id)">
               <button class="diff-badge diff-badge--{{ item.quest.difficulty }}" type="button"
-                (click)="cycleDiff(item.idx); $event.stopPropagation()" matTooltip="Obtížnost — klikni pro změnu">{{ diffLabel(item.quest.difficulty) }}</button>
+                (click)="cycleDiff(item.idx); $event.stopPropagation()" matTooltip="Obtížnost — klikni pro změnu" matTooltipShowDelay="400">{{ diffLabel(item.quest.difficulty) }}</button>
               <!-- Stage pips -->
               <div class="stage-pips">
                 @for (n of [1,2,3,4]; track n) {
@@ -367,8 +366,8 @@ export class DmQuestsComponent {
   collapseAll(): void { this.expandedIds.set(new Set()); }
 
   cycleDiff(idx: number): void {
-    const order: DmQuestDifficulty[] = ['trivial', 'easy', 'medium', 'hard', 'deadly'];
-    this.quests.update(list => list.map((q, i) => i !== idx ? q : { ...q, difficulty: order[(order.indexOf(q.difficulty) + 1) % order.length] }));
+    const order: DmQuestDifficulty[] = ['easy', 'medium', 'hard', 'deadly'];
+    this.quests.update(list => list.map((q, i) => i !== idx ? q : { ...q, difficulty: order[(Math.max(0, order.indexOf(q.difficulty)) + 1) % order.length] as DmQuestDifficulty }));
   }
   setStage(idx: number, stage: number): void {
     this.quests.update(list => list.map((q, i) => i !== idx ? q : { ...q, stage: q.stage === stage ? stage - 1 : stage }));

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -35,7 +35,7 @@ const IMPORTANCE_META: Record<StoryEventImportance, { label: string; color: stri
 };
 
 const TYPE_ORDER: StoryEventType[]            = ['battle', 'discovery', 'npc_met', 'milestone', 'loss', 'other'];
-const IMPORTANCE_ORDER: StoryEventImportance[] = ['minor', 'major', 'epic'];
+const IMPORTANCE_ORDER: StoryEventImportance[] = ['minor', 'major'];
 
 type FilterType = 'all' | StoryEventType;
 type SortOrder  = 'newest' | 'oldest';
@@ -138,30 +138,30 @@ const ACL = '110,190,160'; // lighter teal
     /* ── Card header ────────────────────────────── */
     .card-header { display: flex; align-items: center; gap: 8px; padding: 10px 12px 7px; flex-wrap: wrap; cursor: pointer; user-select: none; }
     .type-badge {
-      font-family: sans-serif; font-size: 8px; letter-spacing: .12em; text-transform: uppercase;
-      border-radius: 10px; padding: 2px 9px; cursor: pointer; border: 1px solid currentColor;
+      font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
+      border-radius: 6px; padding: 4px 12px; cursor: pointer; border: 1px solid currentColor;
       transition: filter .15s; white-space: nowrap; flex-shrink: 0;
       &:hover { filter: brightness(1.18); }
     }
     .importance-badge {
-      font-family: sans-serif; font-size: 7px; letter-spacing: .1em; text-transform: uppercase;
-      border-radius: 2px; padding: 2px 7px; cursor: pointer; transition: filter .15s; white-space: nowrap; flex-shrink: 0;
+      font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
+      border-radius: 6px; padding: 4px 12px; cursor: pointer; transition: filter .15s; white-space: nowrap; flex-shrink: 0;
       border: 1px solid currentColor;
       &:hover { filter: brightness(1.18); }
     }
-    .card-title-wrap { flex: 1; min-width: 0; }
+    .card-title-wrap { flex: 1; min-width: 0; overflow: hidden; }
     .card-title {
-      font-family: sans-serif; font-size: 14px; font-weight: 500; color: #ddd5c5;
-      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      font-family: sans-serif; font-size: 16px; font-weight: 500; color: #ddd5c5;
+      display: flex; align-items: center; gap: 10px; overflow: hidden;
       &--placeholder { color: rgba(200,185,160,.2); font-style: italic; }
     }
-    .card-meta { display: flex; gap: 8px; align-items: center; margin-top: 3px; }
-    .card-date     { font-family: sans-serif; font-size: 9px; color: rgba(175,160,135,.42); letter-spacing: .04em; }
-    .card-location { font-family: sans-serif; font-size: 9px; color: rgba(175,160,135,.32); letter-spacing: .03em;
-      display: flex; align-items: center; gap: 3px;
-      mat-icon { font-size: 10px; width: 10px; height: 10px; }
+    .card-title-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex-shrink: 1; min-width: 0; }
+    .card-date     { font-family: sans-serif; font-size: 9px; color: rgba(175,160,135,.42); letter-spacing: .04em; white-space: nowrap; flex-shrink: 0; }
+    .card-location { font-family: sans-serif; font-size: 10px; color: rgba(175,160,135,.35); letter-spacing: .03em;
+      display: flex; align-items: center; gap: 3px; white-space: nowrap; flex-shrink: 0;
+      mat-icon { font-size: 11px; width: 11px; height: 11px; }
     }
-    .card-actions { display: flex; gap: 2px; margin-left: auto; align-items: center; flex-shrink: 0; }
+    .card-actions { display: flex; gap: 2px; align-items: center; flex-shrink: 0; }
     .card-action-btn {
       background: none; border: none; cursor: pointer; color: rgba(155,140,115,.38); padding: 4px; border-radius: 3px;
       transition: color .15s, background .15s; display: flex; align-items: center;
@@ -175,8 +175,8 @@ const ACL = '110,190,160'; // lighter teal
     /* ── Tag chips (collapsed view) ─────────────── */
     .tag-list { display: flex; gap: 5px; flex-wrap: wrap; padding: 0 12px 8px; }
     .tag-chip {
-      font-family: sans-serif; font-size: 9px; padding: 1px 7px; border-radius: 10px;
-      background: rgba(140,125,100,.1); border: 1px solid rgba(155,140,115,.2); color: rgba(185,170,140,.58);
+      font-family: sans-serif; font-size: 11px; padding: 3px 9px; border-radius: 10px;
+      background: rgba(140,125,100,.1); border: 1px solid rgba(155,140,115,.2); color: rgba(185,170,140,.7);
       letter-spacing: .03em; display: inline-flex; align-items: center; gap: 4px;
     }
 
@@ -192,7 +192,7 @@ const ACL = '110,190,160'; // lighter teal
       &::placeholder { color: rgba(155,140,115,.22); }
     }
     .rt-label { font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: rgba(155,140,115,.38); margin-bottom: 3px; }
-    .rt-wrap { position: relative; height: 110px; background: rgba(140,125,100,.05); border: 1px solid rgba(155,140,115,.13); border-radius: 3px; overflow: hidden; }
+    .rt-wrap { position: relative; height: 160px; background: rgba(140,125,100,.05); border: 1px solid rgba(155,140,115,.13); border-radius: 3px; overflow: visible; margin-top: 44px; }
 
     /* ── Tag input (edit mode) ───────────────────── */
     .tag-input-wrap {
@@ -337,15 +337,16 @@ const ACL = '110,190,160'; // lighter teal
 
               <div class="card-title-wrap">
                 <div class="card-title" [class.card-title--placeholder]="!item.event.title">
-                  {{ item.event.title || 'Bez názvu…' }}
-                </div>
-                <div class="card-meta">
-                  @if (item.event.inGameDate) { <span class="card-date">📅 {{ item.event.inGameDate }}</span> }
+                  <span class="card-title-text">{{ item.event.title || 'Bez názvu…' }}</span>
                   @if (item.event.location) {
                     <span class="card-location"><mat-icon>location_on</mat-icon>{{ item.event.location }}</span>
                   }
                 </div>
               </div>
+
+              @if (item.event.realDate) {
+                <span class="card-date">{{ item.event.realDate }}</span>
+              }
 
               <div class="card-actions" (click)="$event.stopPropagation()">
                 <button class="card-action-btn card-action-btn--danger" (click)="askDelete(item.idx)" matTooltip="Smazat událost">
@@ -385,7 +386,7 @@ const ACL = '110,190,160'; // lighter teal
                     <input class="field-input" [(ngModel)]="events()[item.idx].location" placeholder="Město, dungeon, les…" />
                   </div>
                   <div class="field-group" style="flex:2">
-                    <div class="field-label">Štítky — Enter nebo čárka přidá</div>
+                    <div class="field-label">Štítky</div>
                     <div class="tag-input-wrap" (click)="focusTagInput(item.event.id)">
                       @for (tag of parseTags(events()[item.idx].tags); track tag) {
                         <span class="tag-chip tag-chip--removable">
@@ -402,7 +403,7 @@ const ACL = '110,190,160'; // lighter teal
                         [ngModel]="getTagInput(item.event.id)"
                         (ngModelChange)="setTagInput(item.event.id, $event)"
                         (keydown.enter)="$event.preventDefault(); addTagFromInput(item.idx)"
-                        (keydown.,)="$event.preventDefault(); addTagFromInput(item.idx)"
+                        (keydown.space)="$event.preventDefault(); addTagFromInput(item.idx)"
                         (blur)="addTagFromInput(item.idx)"
                         placeholder="{{ parseTags(events()[item.idx].tags).length ? '' : 'Přidat štítek…' }}"
                       />
@@ -414,21 +415,8 @@ const ACL = '110,190,160'; // lighter teal
                 <div>
                   <div class="rt-label">Shrnutí události</div>
                   <div class="rt-wrap">
-                    <rich-textarea [(ngModel)]="events()[item.idx].summary" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
+                    <rich-textarea [(ngModel)]="events()[item.idx].summary" style="position:absolute;top:0;left:0;width:100%;height:100%;"></rich-textarea>
                   </div>
-                </div>
-
-                <!-- DM notes -->
-                <div>
-                  <button class="dm-section-toggle" (click)="toggleDmNotes(item.event.id)">
-                    <mat-icon>lock</mat-icon> PH poznámky (tajné)
-                    <mat-icon>{{ dmNotesOpen().has(item.event.id) ? 'expand_less' : 'expand_more' }}</mat-icon>
-                  </button>
-                  @if (dmNotesOpen().has(item.event.id)) {
-                    <div class="dm-rt-wrap">
-                      <rich-textarea [(ngModel)]="events()[item.idx].dmNotes" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
-                    </div>
-                  }
                 </div>
 
               </div>
@@ -568,12 +556,12 @@ export class DmStoryTimelineComponent {
     const val = this.getTagInput(id).trim(); if (!val) return;
     const existing = this.parseTags(this.events()[idx].tags);
     if (!existing.includes(val)) {
-      this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...existing, val].join(', ') }));
+      this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...existing, val].join(' ') }));
     }
     this.setTagInput(id, '');
   }
   removeTag(idx: number, tag: string): void {
-    this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: this.parseTags(e.tags).filter(t => t !== tag).join(', ') }));
+    this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: this.parseTags(e.tags).filter(t => t !== tag).join(' ') }));
   }
 
   // ── CRUD ──────────────────────────────────────────────────────────────────
@@ -620,6 +608,6 @@ export class DmStoryTimelineComponent {
   // ── Helpers ───────────────────────────────────────────────────────────────
   typeMeta(t: StoryEventType)            { return TYPE_META[t]; }
   importanceMeta(i: StoryEventImportance){ return IMPORTANCE_META[i]; }
-  parseTags(tags: string): string[]      { return tags.split(',').map(t => t.trim()).filter(Boolean); }
+  parseTags(tags: string): string[]      { return tags.split(/[,\s]+/).map(t => t.trim()).filter(Boolean); }
 }
 

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -19,7 +19,7 @@ import { StoryEventsListComponent } from './story-events-list.component';
   selector: 'dm-story-timeline',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormsModule, MatIcon, MatTooltip, SpinnerOverlayComponent, StoryEventsListComponent],
-  host: { '(document:keydown.escape)': 'onEscape()' },
+  host: { '(document:keydown.escape)': 'onEscape()', '(document:keydown.control.s)': 'ctrlSave($event)' },
   styles: `
     :host { display: block; padding: 13px 0 20px; font-family: sans-serif; overflow: visible; }
 
@@ -378,6 +378,7 @@ export class DmStoryTimelineComponent {
   }
 
   onEscape(): void { if (this.shareDialogOpen()) this.shareDialogOpen.set(false); }
+  ctrlSave(e: Event): void { e.preventDefault(); if (this.activeTab() === 'own') this.save(); }
 
   typeLabel(t: string): string {
     const labels: Record<string, string> = {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -148,7 +148,7 @@ import { StoryEventsListComponent } from './story-events-list.component';
       <!-- Tag filter row -->
       @if (allTags().length > 0) {
         <div class="tag-filter-row">
-          <span class="tag-filter-label">Štítek:</span>
+          <span class="tag-filter-label">Štítky:</span>
           <button class="tag-filter-chip" [class.tag-filter-chip--active]="filterTag() === null" (click)="filterTag.set(null)">vše</button>
           @for (tag of allTags(); track tag) {
             <button class="tag-filter-chip" [class.tag-filter-chip--active]="filterTag() === tag" (click)="filterTag.set(filterTag() === tag ? null : tag)">{{ tag }}</button>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -19,11 +19,51 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { DmPageStore } from '../../dm-page.store';
 import { StoryEvent, StoryEventType } from '../../dm-page-models';
 
+// ── Fuzzy-search helpers ──────────────────────────────────────────────────────
+function posNorm(s: string): string {
+  return s.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase();
+}
+
+function fuzzySubsequence(query: string, text: string): number[] | null {
+  const indices: number[] = [];
+  let ti = 0;
+  for (let qi = 0; qi < query.length; qi++) {
+    const ch = query[qi];
+    while (ti < text.length && text[ti] !== ch) ti++;
+    if (ti >= text.length) return null;
+    indices.push(ti);
+    ti++;
+  }
+  return indices;
+}
+
+function escHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function buildHighlightHtml(original: string, indices: number[]): string {
+  const matchSet = new Set(indices);
+  const parts: string[] = [];
+  let inSpan = false;
+  for (let i = 0; i < original.length; i++) {
+    const ch = escHtml(original[i]);
+    if (matchSet.has(i)) {
+      if (!inSpan) { parts.push('<span class="hl">'); inSpan = true; }
+      parts.push(ch);
+    } else {
+      if (inSpan) { parts.push('</span>'); inSpan = false; }
+      parts.push(ch);
+    }
+  }
+  if (inSpan) parts.push('</span>');
+  return parts.join('');
+}
+
 const TYPE_META: Record<StoryEventType, { label: string; icon: string; color: string; bg: string }> = {
-  world:     { label: 'Světové události',  icon: 'public',       color: 'rgba(100,140,210,.9)', bg: 'rgba(70,110,190,.10)' },
-  campaign:  { label: 'Události kampaně',  icon: 'auto_stories', color: 'rgba(210,175,55,.9)',  bg: 'rgba(190,155,40,.10)' },
-  character: { label: 'Události postav',   icon: 'person',       color: 'rgba(60,185,150,.9)',  bg: 'rgba(40,160,120,.10)' },
-  other:     { label: 'Jiné',              icon: 'bookmark',     color: 'rgba(130,130,130,.8)', bg: 'rgba(100,100,100,.08)'},
+  world:     { label: 'Světová událost',  icon: 'public',       color: 'rgba(100,140,210,.9)', bg: 'rgba(70,110,190,.10)' },
+  campaign:  { label: 'Událost kampaně',  icon: 'auto_stories', color: 'rgba(210,175,55,.9)',  bg: 'rgba(190,155,40,.10)' },
+  character: { label: 'Událost postav',   icon: 'person',       color: 'rgba(60,185,150,.9)',  bg: 'rgba(40,160,120,.10)' },
+  other:     { label: 'Jiné',             icon: 'bookmark',     color: 'rgba(130,130,130,.8)', bg: 'rgba(100,100,100,.08)'},
 };
 
 const TYPE_ORDER: StoryEventType[] = ['world', 'campaign', 'character', 'other'];
@@ -87,10 +127,10 @@ const ACL = '110,190,160'; // lighter teal
 
     /* ── Tag filter row ──────────────────────────── */
     .tag-filter-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 20px; padding: 6px 0; }
-    .tag-filter-label { font-family: sans-serif; font-size: 9px; letter-spacing: .12em; text-transform: uppercase; color: rgba(155,140,115,.4); flex-shrink: 0; }
+    .tag-filter-label { font-family: sans-serif; font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: rgba(155,140,115,.4); flex-shrink: 0; }
     .tag-filter-chip {
-      font-family: sans-serif; font-size: 10px; padding: 2px 8px; border-radius: 10px; cursor: pointer; border: 1px solid; transition: background .12s, color .12s;
-      background: transparent; color: rgba(155,140,115,.55); border-color: rgba(155,140,115,.2);
+      font-family: sans-serif; font-size: 12px; padding: 3px 10px; border-radius: 10px; cursor: pointer; border: 1px solid; transition: background .12s, color .12s;
+      background: transparent; color: rgba(155,140,115,.65); border-color: rgba(155,140,115,.2);
       &:hover { background: rgba(140,125,100,.1); color: rgba(175,160,135,.85); border-color: rgba(155,140,115,.4); }
       &--active { background: rgba(140,125,100,.2); color: #d8cdb8; border-color: rgba(155,140,115,.6); }
     }
@@ -189,10 +229,30 @@ const ACL = '110,190,160'; // lighter teal
       color: rgba(185,170,140,.52); font-style: italic;
     }
     .tag-chip-remove {
-      background: none; border: none; cursor: pointer; color: rgba(185,170,140,.48); font-size: 12px; line-height: 1;
-      padding: 0 1px; display: flex; align-items: center; transition: color .12s;
-      &:hover { color: rgba(220,80,70,.8); }
+      background: none; border: none; cursor: pointer; color: rgba(185,170,140,.55); font-size: 14px; line-height: 1;
+      padding: 2px 4px; display: flex; align-items: center; transition: color .12s, background .12s; border-radius: 3px;
+      &:hover { color: rgba(220,80,70,.9); background: rgba(200,50,40,.15); }
     }
+
+    /* ── Tag suggestion dropdown ─────────────────── */
+    .tag-field-wrap { position: relative; }
+    .tag-suggestions {
+      position: absolute; top: calc(100% + 2px); left: 0; right: 0; z-index: 200;
+      background: rgba(18,14,8,.98);
+      border: 1px solid rgba(155,140,115,.35);
+      border-radius: 4px;
+      max-height: 180px; overflow-y: auto;
+      box-shadow: 0 6px 20px rgba(0,0,0,.7);
+    }
+    .tag-suggestion-item {
+      display: block; width: 100%; text-align: left; padding: 7px 12px;
+      background: none; border: none; border-bottom: 1px solid rgba(155,140,115,.08);
+      color: rgba(220,210,190,.75); font-size: 11px; font-family: sans-serif; cursor: pointer;
+      transition: background .1s, color .1s;
+      &:last-child { border-bottom: none; }
+      &:hover, &--active { background: rgba(155,140,115,.12); color: #d8cdb8; }
+    }
+    ::ng-deep .tag-suggestions .hl { color: rgba(210,175,55,.95); font-weight: 700; }
     .tag-text-input {
       background: transparent; border: none; outline: none; color: rgba(220,210,190,.85);
       font-family: sans-serif; font-size: 12px; min-width: 100px; flex: 1;
@@ -362,26 +422,41 @@ const ACL = '110,190,160'; // lighter teal
                   </div>
                   <div class="field-group" style="flex:2">
                     <div class="field-label">Štítky</div>
-                    <div class="tag-input-wrap" (click)="focusTagInput(item.event.id)">
-                      @for (tag of parseTags(events()[item.idx].tags); track tag) {
-                        <span class="tag-chip tag-chip--removable">
-                          {{ tag }}
-                          <button class="tag-chip-remove" type="button" (click)="$event.stopPropagation(); removeTag(item.idx, tag)">×</button>
-                        </span>
+                    <div class="tag-field-wrap">
+                      <div class="tag-input-wrap" (click)="focusTagInput(item.event.id)">
+                        @for (tag of parseTags(events()[item.idx].tags); track tag) {
+                          <span class="tag-chip tag-chip--removable">
+                            {{ tag }}
+                            <button class="tag-chip-remove" type="button" (click)="$event.stopPropagation(); removeTag(item.idx, tag)">×</button>
+                          </span>
+                        }
+                        <input
+                          class="tag-text-input"
+                          [id]="'tag-input-' + item.event.id"
+                          [ngModel]="getTagInput(item.event.id)"
+                          (ngModelChange)="setTagInput(item.event.id, $event)"
+                          (keydown.enter)="$event.preventDefault(); onTagEnter(item.idx, item.event.id)"
+                          (keydown.space)="$event.preventDefault(); addTagFromInput(item.idx)"
+                          (keydown.arrowdown)="$event.preventDefault(); navigateSuggestions(item.event.id, 1)"
+                          (keydown.arrowup)="$event.preventDefault(); navigateSuggestions(item.event.id, -1)"
+                          (keydown.escape)="setActiveSuggIdx(item.event.id, -1)"
+                          (blur)="onTagBlur(item.idx)"
+                          placeholder="{{ parseTags(events()[item.idx].tags).length ? '' : 'Přidat štítek…' }}"
+                        />
+                      </div>
+                      @if (getTagSuggestions(item.event.id).length > 0) {
+                        <div class="tag-suggestions">
+                          @for (sugg of getTagSuggestions(item.event.id); track sugg.tag; let si = $index) {
+                            <button
+                              class="tag-suggestion-item"
+                              [class.tag-suggestion-item--active]="getActiveSuggIdx(item.event.id) === si"
+                              type="button"
+                              (mousedown)="$event.preventDefault()"
+                              (click)="selectSuggestion(item.idx, sugg.tag)"
+                            ><span [innerHTML]="sugg.html"></span></button>
+                          }
+                        </div>
                       }
-                      @if (getTagInput(item.event.id).trim()) {
-                        <span class="tag-chip tag-chip--preview">{{ getTagInput(item.event.id).trim() }}</span>
-                      }
-                      <input
-                        class="tag-text-input"
-                        [id]="'tag-input-' + item.event.id"
-                        [ngModel]="getTagInput(item.event.id)"
-                        (ngModelChange)="setTagInput(item.event.id, $event)"
-                        (keydown.enter)="$event.preventDefault(); addTagFromInput(item.idx)"
-                        (keydown.space)="$event.preventDefault(); addTagFromInput(item.idx)"
-                        (blur)="addTagFromInput(item.idx)"
-                        placeholder="{{ parseTags(events()[item.idx].tags).length ? '' : 'Přidat štítek…' }}"
-                      />
                     </div>
                   </div>
                 </div>
@@ -518,9 +593,68 @@ export class DmStoryTimelineComponent {
     this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, type: TYPE_ORDER[(TYPE_ORDER.indexOf(e.type) + 1) % TYPE_ORDER.length] }));
   }
   // ── Tags ──────────────────────────────────────────────────────────────────
-  getTagInput(id: string): string                  { return this.tagInputMap()[id] ?? ''; }
-  setTagInput(id: string, val: string): void       { this.tagInputMap.update(m => ({ ...m, [id]: val })); }
-  focusTagInput(id: string): void                  { document.getElementById('tag-input-' + id)?.focus(); }
+  private readonly activeSuggIdxMap = signal<Record<string, number>>({});
+
+  getTagInput(id: string): string            { return this.tagInputMap()[id] ?? ''; }
+  setTagInput(id: string, val: string): void { this.tagInputMap.update(m => ({ ...m, [id]: val })); this.setActiveSuggIdx(id, -1); }
+  focusTagInput(id: string): void            { document.getElementById('tag-input-' + id)?.focus(); }
+
+  getActiveSuggIdx(id: string): number            { return this.activeSuggIdxMap()[id] ?? -1; }
+  setActiveSuggIdx(id: string, n: number): void   { this.activeSuggIdxMap.update(m => ({ ...m, [id]: n })); }
+
+  getTagSuggestions(eventId: string): Array<{ tag: string; html: string }> {
+    const rawQuery = this.getTagInput(eventId).trim();
+    if (!rawQuery) return [];
+    const query = posNorm(rawQuery);
+    const existingSet = new Set(this.parseTags(this.events().find(e => e.id === eventId)?.tags ?? ''));
+    return this.allTags()
+      .filter(tag => !existingSet.has(tag))
+      .map(tag => {
+        const indices = fuzzySubsequence(query, posNorm(tag));
+        if (!indices) return null;
+        return { tag, html: buildHighlightHtml(tag, indices) };
+      })
+      .filter((x): x is { tag: string; html: string } => x !== null);
+  }
+
+  selectSuggestion(idx: number, tag: string): void {
+    const id = this.events()[idx]?.id; if (!id) return;
+    const existing = this.parseTags(this.events()[idx].tags);
+    if (!existing.includes(tag)) {
+      this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...this.parseTags(e.tags), tag].join(' ') }));
+    }
+    this.setTagInput(id, '');
+    this.setActiveSuggIdx(id, -1);
+    document.getElementById('tag-input-' + id)?.focus();
+  }
+
+  navigateSuggestions(id: string, dir: 1 | -1): void {
+    const len = this.getTagSuggestions(id).length;
+    if (!len) return;
+    const next = Math.max(-1, Math.min(len - 1, this.getActiveSuggIdx(id) + dir));
+    this.setActiveSuggIdx(id, next);
+  }
+
+  onTagEnter(idx: number, id: string): void {
+    const activeIdx = this.getActiveSuggIdx(id);
+    const suggestions = this.getTagSuggestions(id);
+    if (activeIdx >= 0 && activeIdx < suggestions.length) {
+      this.selectSuggestion(idx, suggestions[activeIdx].tag);
+    } else {
+      this.addTagFromInput(idx);
+    }
+  }
+
+  onTagBlur(idx: number): void {
+    const id = this.events()[idx]?.id; if (!id) return;
+    this.setActiveSuggIdx(id, -1);
+    const val = this.getTagInput(id).trim(); if (!val) return;
+    const existing = this.parseTags(this.events()[idx].tags);
+    if (!existing.includes(val)) {
+      this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...existing, val].join(' ') }));
+    }
+    this.setTagInput(id, '');
+  }
 
   addTagFromInput(idx: number): void {
     const id  = this.events()[idx]?.id; if (!id) return;

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -50,7 +50,7 @@ const ACL = '110,190,160'; // lighter teal
   imports: [FormsModule, MatIcon, MatIconButton, MatTooltip, SpinnerOverlayComponent, RichTextareaComponent],
   host: { '(document:keydown.escape)': 'onEscape()' },
   styles: `
-    :host { display: block; padding: 24px 32px 60px; font-family: sans-serif; overflow: visible; }
+    :host { display: block; padding: 13px 0 20px; font-family: sans-serif; overflow: visible; }
 
     /* ── Header ───────────────────────────────────── */
     .header {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -23,16 +23,6 @@ import { StoryEventsListComponent } from './story-events-list.component';
   styles: `
     :host { display: block; padding: 13px 0 20px; font-family: sans-serif; overflow: visible; }
 
-    /* ── Buttons ─────────────────────────────────── */
-    .btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
-      border: 1px solid rgba(155,140,115,.35); border-radius: 3px; background: rgba(140,125,100,.08); color: rgba(175,160,135,.85);
-      padding: 6px 14px; cursor: pointer; display: flex; align-items: center; gap: 5px; transition: background .18s, border-color .18s, color .18s;
-      mat-icon { font-size: 15px; width: 15px; height: 15px; }
-      &:hover { background: rgba(140,125,100,.16); border-color: rgba(155,140,115,.6); color: #d8cdb8; }
-    }
-    .btn-save { border-color: rgba(80,160,80,.35); color: rgba(100,200,100,.8); background: rgba(60,120,60,.08);
-      &:hover { background: rgba(60,140,60,.18); border-color: rgba(80,180,80,.6); color: #80e080; }
-    }
 
     /* ── pt-filter-btn icon support ─────────────── */
     .pt-filter-btn { display: inline-flex; align-items: center; gap: 5px;
@@ -141,7 +131,7 @@ import { StoryEventsListComponent } from './story-events-list.component';
           <button class="pt-filter-btn" (click)="openShareDialog()" matTooltip="Sdílet moje události s hráči">
             <mat-icon>share</mat-icon> Sdílet
           </button>
-          <button class="btn btn-save" (click)="save()"><mat-icon>save</mat-icon> Uložit</button>
+          <button class="pt-filter-btn" (click)="save()"><mat-icon>save</mat-icon> Uložit</button>
         }
       </div>
 
@@ -228,7 +218,7 @@ import { StoryEventsListComponent } from './story-events-list.component';
 
           <div class="share-dialog__actions">
             <button class="pt-filter-btn" type="button" (click)="shareDialogOpen.set(false)">Zrušit</button>
-            <button class="btn btn-save" type="button" (click)="saveSharing()">
+            <button class="pt-filter-btn" type="button" (click)="saveSharing()">
               <mat-icon>save</mat-icon> Uložit sdílení
             </button>
           </div>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -17,25 +17,16 @@ import { SpinnerOverlayComponent, RichTextareaComponent } from '@dn-d-servant/ui
 import { AuthService } from '@dn-d-servant/util';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { DmPageStore } from '../../dm-page.store';
-import { StoryEvent, StoryEventImportance, StoryEventType } from '../../dm-page-models';
+import { StoryEvent, StoryEventType } from '../../dm-page-models';
 
 const TYPE_META: Record<StoryEventType, { label: string; icon: string; color: string; bg: string }> = {
-  battle:    { label: 'Bitva',   icon: 'swords',       color: 'rgba(210,80,65,.9)',   bg: 'rgba(190,60,45,.12)'  },
-  discovery: { label: 'Objev',   icon: 'explore',      color: 'rgba(60,185,150,.9)',  bg: 'rgba(40,160,120,.10)' },
-  npc_met:   { label: 'Setkání', icon: 'person_add',   color: 'rgba(100,140,210,.9)', bg: 'rgba(70,110,190,.10)' },
-  milestone: { label: 'Milník',  icon: 'star',         color: 'rgba(210,175,55,.9)',  bg: 'rgba(190,155,40,.10)' },
-  loss:      { label: 'Ztráta',  icon: 'heart_broken', color: 'rgba(170,80,120,.9)',  bg: 'rgba(140,55,95,.10)'  },
-  other:     { label: 'Ostatní', icon: 'bookmark',     color: 'rgba(130,130,130,.8)', bg: 'rgba(100,100,100,.08)'},
+  world:     { label: 'Světové události',  icon: 'public',       color: 'rgba(100,140,210,.9)', bg: 'rgba(70,110,190,.10)' },
+  campaign:  { label: 'Události kampaně',  icon: 'auto_stories', color: 'rgba(210,175,55,.9)',  bg: 'rgba(190,155,40,.10)' },
+  character: { label: 'Události postav',   icon: 'person',       color: 'rgba(60,185,150,.9)',  bg: 'rgba(40,160,120,.10)' },
+  other:     { label: 'Jiné',              icon: 'bookmark',     color: 'rgba(130,130,130,.8)', bg: 'rgba(100,100,100,.08)'},
 };
 
-const IMPORTANCE_META: Record<StoryEventImportance, { label: string; color: string; glow: string }> = {
-  minor: { label: 'Vedlejší', color: 'rgba(130,130,130,.7)',  glow: 'none' },
-  major: { label: 'Hlavní',  color: 'rgba(200,160,60,.85)',   glow: '0 0 8px rgba(200,160,60,.3)' },
-  epic:  { label: 'Epický',  color: 'rgba(210,175,55,.95)',   glow: '0 0 14px rgba(200,160,40,.45)' },
-};
-
-const TYPE_ORDER: StoryEventType[]            = ['battle', 'discovery', 'npc_met', 'milestone', 'loss', 'other'];
-const IMPORTANCE_ORDER: StoryEventImportance[] = ['minor', 'major'];
+const TYPE_ORDER: StoryEventType[] = ['world', 'campaign', 'character', 'other'];
 
 type FilterType = 'all' | StoryEventType;
 type SortOrder  = 'newest' | 'oldest';
@@ -119,12 +110,6 @@ const ACL = '110,190,160'; // lighter teal
       border: 2px solid; background: rgba(14,12,8,.96);
       mat-icon { font-size: 14px; width: 14px; height: 14px; }
     }
-    .tl-node--epic { animation: epicPulse 2.5s ease-in-out infinite; }
-    @keyframes epicPulse {
-      0%, 100% { box-shadow: 0 0 0 0 rgba(200,160,40,.0); }
-      50%       { box-shadow: 0 0 0 7px rgba(200,160,40,.28); }
-    }
-
     /* ── Event card ──────────────────────────────── */
     .event-card {
       position: relative; border-radius: 3px; margin-bottom: 20px;
@@ -141,12 +126,6 @@ const ACL = '110,190,160'; // lighter teal
       font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
       border-radius: 6px; padding: 4px 12px; cursor: pointer; border: 1px solid currentColor;
       transition: filter .15s; white-space: nowrap; flex-shrink: 0;
-      &:hover { filter: brightness(1.18); }
-    }
-    .importance-badge {
-      font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
-      border-radius: 6px; padding: 4px 12px; cursor: pointer; transition: filter .15s; white-space: nowrap; flex-shrink: 0;
-      border: 1px solid currentColor;
       &:hover { filter: brightness(1.18); }
     }
     .card-title-wrap { flex: 1; min-width: 0; overflow: hidden; }
@@ -318,12 +297,11 @@ const ACL = '110,190,160'; // lighter teal
         }
 
         @for (item of filtered(); track item.event.id) {
-          <div class="event-card" [class.event-card--epic]="item.event.importance === 'epic'">
+          <div class="event-card">
 
-            <div class="tl-node" [class.tl-node--epic]="item.event.importance === 'epic'"
+            <div class="tl-node"
               [style.border-color]="typeMeta(item.event.type).color"
-              [style.color]="typeMeta(item.event.type).color"
-              [style.box-shadow]="importanceMeta(item.event.importance).glow">
+              [style.color]="typeMeta(item.event.type).color">
               <mat-icon>{{ typeMeta(item.event.type).icon }}</mat-icon>
             </div>
 
@@ -331,9 +309,6 @@ const ACL = '110,190,160'; // lighter teal
             <div class="card-header" (click)="toggleExpand(item.event.id)">
               <span class="type-badge" [style.color]="typeMeta(item.event.type).color" [style.background]="typeMeta(item.event.type).bg"
                 (click)="$event.stopPropagation(); cycleType(item.idx)" matTooltip="Kliknutím změnit typ">{{ typeMeta(item.event.type).label }}</span>
-
-              <span class="importance-badge" [style.color]="importanceMeta(item.event.importance).color" [style.box-shadow]="importanceMeta(item.event.importance).glow"
-                (click)="$event.stopPropagation(); cycleImportance(item.idx)" matTooltip="Kliknutím změnit důležitost">{{ importanceMeta(item.event.importance).label }}</span>
 
               <div class="card-title-wrap">
                 <div class="card-title" [class.card-title--placeholder]="!item.event.title">
@@ -525,7 +500,7 @@ export class DmStoryTimelineComponent {
 
   addEvent(): void {
     const id = crypto.randomUUID();
-    this.events.update(list => [{ id, title: '', inGameDate: '', realDate: new Date().toISOString().split('T')[0], type: 'other', importance: 'minor', summary: '', dmNotes: '', imageBase64: null, location: '', tags: '' } as StoryEvent, ...list]);
+    this.events.update(list => [{ id, title: '', inGameDate: '', realDate: new Date().toISOString().split('T')[0], type: 'other', summary: '', dmNotes: '', imageBase64: null, location: '', tags: '' } as StoryEvent, ...list]);
     this.expandedIds.update(s => new Set([...s, id]));
   }
 
@@ -542,10 +517,6 @@ export class DmStoryTimelineComponent {
   cycleType(idx: number): void {
     this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, type: TYPE_ORDER[(TYPE_ORDER.indexOf(e.type) + 1) % TYPE_ORDER.length] }));
   }
-  cycleImportance(idx: number): void {
-    this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, importance: IMPORTANCE_ORDER[(IMPORTANCE_ORDER.indexOf(e.importance) + 1) % IMPORTANCE_ORDER.length] }));
-  }
-
   // ── Tags ──────────────────────────────────────────────────────────────────
   getTagInput(id: string): string                  { return this.tagInputMap()[id] ?? ''; }
   setTagInput(id: string, val: string): void       { this.tagInputMap.update(m => ({ ...m, [id]: val })); }
@@ -606,8 +577,7 @@ export class DmStoryTimelineComponent {
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────
-  typeMeta(t: StoryEventType)            { return TYPE_META[t]; }
-  importanceMeta(i: StoryEventImportance){ return IMPORTANCE_META[i]; }
+  typeMeta(t: string) { return TYPE_META[t as StoryEventType] ?? TYPE_META['other']; }
   parseTags(tags: string): string[]      { return tags.split(/[,\s]+/).map(t => t.trim()).filter(Boolean); }
 }
 

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -78,8 +78,14 @@ const ACL = '110,190,160'; // lighter teal
       &:hover { background: rgba(60,140,60,.18); border-color: rgba(80,180,80,.6); color: #80e080; }
     }
 
+    /* ── pt-filter-btn icon support ─────────────── */
+    .pt-filter-btn { display: inline-flex; align-items: center; gap: 5px;
+      mat-icon, .mat-icon { font-size: 14px; width: 14px; height: 14px; }
+    }
+
     /* ── Filter / sort bar ───────────────────────── */
-    .filter-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
+    .filter-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
+    .filter-bar-spacer { flex: 1; }
     .filter-count { background: rgba(255,255,255,.08); border-radius: 10px; padding: 0 6px; font-size: 9px; min-width: 18px; text-align: center; line-height: 16px; }
     .sort-select {
       font-family: sans-serif; font-size: 10px; letter-spacing: .08em;
@@ -122,16 +128,12 @@ const ACL = '110,190,160'; // lighter teal
     /* ── Event card ──────────────────────────────── */
     .event-card {
       position: relative; border-radius: 3px; margin-bottom: 20px;
-      background: linear-gradient(160deg, rgba(22,19,14,.97) 0%, rgba(14,12,8,.99) 100%);
-      border: 1px solid rgba(155,140,115,.13);
-      border-left: 3px solid transparent;
-      box-shadow: 0 4px 20px rgba(0,0,0,.55), inset 0 1px 0 rgba(155,140,115,.03);
+      background: rgba(22,20,18,.97);
+      border: 1px solid rgba(200,160,60,.15);
+      box-shadow: 0 4px 20px rgba(0,0,0,.55);
       transition: border-color .2s, box-shadow .2s; overflow: hidden;
-      &::before { content: '◆'; position: absolute; top: 5px; left: 8px; font-size: 6px; color: rgba(155,140,115,.16); pointer-events: none; }
-      &:hover { box-shadow: 0 6px 28px rgba(0,0,0,.65), 0 0 10px rgba(155,140,115,.04); }
+      &:hover { border-color: rgba(200,160,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65); }
     }
-    .event-card--epic { box-shadow: 0 4px 24px rgba(0,0,0,.6), 0 0 18px rgba(200,160,40,.07) !important; }
-    .card-rule { height: 2px; background: linear-gradient(90deg, rgba(155,140,115,.0) 0%, rgba(155,140,115,.3) 30%, rgba(185,170,140,.5) 50%, rgba(155,140,115,.3) 70%, rgba(155,140,115,.0) 100%); }
 
     /* ── Card header ────────────────────────────── */
     .card-header { display: flex; align-items: center; gap: 8px; padding: 10px 12px 7px; flex-wrap: wrap; cursor: pointer; user-select: none; }
@@ -270,14 +272,7 @@ const ACL = '110,190,160'; // lighter teal
   template: `
     <spinner-overlay [diameter]="60" [showSpinner]="store.loading()">
 
-      <div class="header-actions">
-        <button class="btn btn-icon" (click)="expandAll()" matTooltip="Rozbalit vše"><mat-icon>unfold_more</mat-icon></button>
-        <button class="btn btn-icon" (click)="collapseAll()" matTooltip="Sbalit vše"><mat-icon>unfold_less</mat-icon></button>
-        <button class="btn" (click)="addEvent()"><mat-icon>add</mat-icon> Přidat událost</button>
-        <button class="btn btn-save" (click)="save()"><mat-icon>save</mat-icon> Uložit</button>
-      </div>
-
-      <!-- Type filter + sort -->
+      <!-- Filter + actions row -->
       <div class="filter-bar">
         <button class="pt-filter-btn" [class.active]="filterType() === 'all'" (click)="filterType.set('all')">
           Vše <span class="filter-count">{{ events().length }}</span>
@@ -291,6 +286,12 @@ const ACL = '110,190,160'; // lighter teal
           <option value="newest">Nejnovější první</option>
           <option value="oldest">Nejstarší první</option>
         </select>
+        <span class="filter-bar-spacer"></span>
+        <button class="pt-filter-btn" (click)="toggleAllExpanded()" [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozbalit vše'">
+          <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+        </button>
+        <button class="pt-filter-btn" (click)="addEvent()"><mat-icon>add</mat-icon> Přidat událost</button>
+        <button class="btn btn-save" (click)="save()"><mat-icon>save</mat-icon> Uložit</button>
       </div>
 
       <!-- Tag filter row -->
@@ -317,8 +318,7 @@ const ACL = '110,190,160'; // lighter teal
         }
 
         @for (item of filtered(); track item.event.id) {
-          <div class="event-card" [class.event-card--epic]="item.event.importance === 'epic'" [style.border-left-color]="typeMeta(item.event.type).color">
-            <div class="card-rule"></div>
+          <div class="event-card" [class.event-card--epic]="item.event.importance === 'epic'">
 
             <div class="tl-node" [class.tl-node--epic]="item.event.importance === 'epic'"
               [style.border-color]="typeMeta(item.event.type).color"
@@ -370,19 +370,11 @@ const ACL = '110,190,160'; // lighter teal
             @if (expandedIds().has(item.event.id)) {
               <div class="card-body">
 
-                <!-- Row 1: title + in-game date + real date -->
+                <!-- Row 1: title -->
                 <div class="field-row">
-                  <div class="field-group" style="flex:2;min-width:200px">
+                  <div class="field-group" style="flex:1;min-width:200px">
                     <div class="field-label">Název události</div>
                     <input class="field-input" [(ngModel)]="events()[item.idx].title" placeholder="Název…" />
-                  </div>
-                  <div class="field-group">
-                    <div class="field-label">Datum v příběhu</div>
-                    <input class="field-input" [(ngModel)]="events()[item.idx].inGameDate" placeholder="15. Flamerule 1492…" />
-                  </div>
-                  <div class="field-group">
-                    <div class="field-label">Datum záznamu</div>
-                    <input class="field-input" type="date" [(ngModel)]="events()[item.idx].realDate" />
                   </div>
                 </div>
 
@@ -424,24 +416,6 @@ const ACL = '110,190,160'; // lighter teal
                   <div class="rt-wrap">
                     <rich-textarea [(ngModel)]="events()[item.idx].summary" style="top:0;left:0;width:100%;height:100%;"></rich-textarea>
                   </div>
-                </div>
-
-                <!-- Image -->
-                <div class="img-zone" [class.img-zone--dragover]="dragOver() === item.idx"
-                  (click)="selectImage(item.idx)"
-                  (dragover)="onDragOver($event, item.idx)"
-                  (dragleave)="dragOver.set(null)"
-                  (drop)="onDrop($event, item.idx)"
-                  matTooltip="Klikni nebo přetáhni obrázek (max 200 KB)">
-                  @if (item.event.imageBase64) {
-                    <img class="img-preview" [src]="'data:image/png;base64,' + item.event.imageBase64" [alt]="item.event.title"
-                      (click)="$event.stopPropagation(); openPreview($event, item.event)" />
-                    <button class="img-remove-btn" (click)="$event.stopPropagation(); removeImage(item.idx)" matTooltip="Odebrat obrázek">
-                      <mat-icon>close</mat-icon>
-                    </button>
-                  } @else {
-                    <div class="img-placeholder"><mat-icon>image</mat-icon>Obrázek (volitelné)</div>
-                  }
                 </div>
 
                 <!-- DM notes -->
@@ -567,9 +541,14 @@ export class DmStoryTimelineComponent {
     this.expandedIds.update(s => new Set([...s, id]));
   }
 
+  readonly allExpanded = computed(() =>
+    this.events().length > 0 && this.events().every(e => this.expandedIds().has(e.id))
+  );
+
   toggleExpand(id: string): void  { this.expandedIds.update(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; }); }
   expandAll():  void               { this.expandedIds.set(new Set(this.events().map(e => e.id))); }
   collapseAll(): void              { this.expandedIds.set(new Set()); }
+  toggleAllExpanded(): void        { this.allExpanded() ? this.collapseAll() : this.expandAll(); }
   toggleDmNotes(id: string): void  { this.dmNotesOpen.update(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; }); }
 
   cycleType(idx: number): void {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -92,12 +92,20 @@ import { StoryEventsListComponent } from './story-events-list.component';
       padding: 6px 10px; background: rgba(200,160,60,.06); border: 1px solid rgba(200,160,60,.15); border-radius: 4px;
     }
     .share-dialog__player-name { font-family: sans-serif; font-size: 12px; color: rgba(220,200,150,.85); }
+    .share-check-icon {
+      font-size: 16px !important; width: 16px !important; height: 16px !important; flex-shrink: 0;
+      &--ok      { color: rgba(80,190,90,.85); }
+      &--warn    { color: rgba(210,80,70,.75); }
+      &--checking { color: rgba(200,160,60,.5); animation: spin .8s linear infinite; }
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
     .share-dialog__remove {
       background: none; border: none; cursor: pointer; color: rgba(200,80,70,.5); font-size: 16px; line-height: 1;
       padding: 2px 4px; border-radius: 2px; transition: color .12s, background .12s;
       &:hover { color: rgba(220,80,70,.9); background: rgba(200,50,40,.12); }
     }
-    .share-dialog__actions { display: flex; gap: 8px; justify-content: flex-end; padding-top: 4px; border-top: 1px solid rgba(200,160,60,.12); margin-top: 4px; }
+    .share-dialog__actions { display: flex; gap: 8px; justify-content: flex-end; padding-top: 4px; margin-top: 4px; }
 
     @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
     @keyframes scaleIn { from { transform: scale(.92); opacity: 0; } to { transform: scale(1); opacity: 1; } }
@@ -165,6 +173,7 @@ import { StoryEventsListComponent } from './story-events-list.component';
             [filterType]="filterType()"
             [filterTag]="filterTag()"
             [sortOrder]="sortOrder()"
+            storageKey="dnd_story_expanded_shared"
           />
         } @else {
           <div class="no-shared">
@@ -183,6 +192,7 @@ import { StoryEventsListComponent } from './story-events-list.component';
           [filterTag]="filterTag()"
           [sortOrder]="sortOrder()"
           [autoExpandId]="newEventId()"
+          storageKey="dnd_story_expanded_own"
         />
       }
 
@@ -193,7 +203,7 @@ import { StoryEventsListComponent } from './story-events-list.component';
       <div class="share-backdrop" (click)="shareDialogOpen.set(false)">
         <div class="share-dialog" (click)="$event.stopPropagation()">
           <div class="share-dialog__title">Sdílet příběhové události</div>
-          <div class="share-dialog__desc">Pozvaní hráči uvidí tvoje události v režimu pouze pro čtení.</div>
+          <div class="share-dialog__desc">Pozvaní hráči uvidí tvoje události. Editování je pro ně vypnuté.</div>
 
           <div class="share-dialog__section-label">Přidat hráče</div>
           <div class="share-dialog__input-row">
@@ -210,6 +220,13 @@ import { StoryEventsListComponent } from './story-events-list.component';
             }
             @for (player of pendingSharedWith(); track player) {
               <div class="share-dialog__player">
+                @if (userCheckStatus()[player] === 'checking') {
+                  <mat-icon class="share-check-icon share-check-icon--checking">hourglass_empty</mat-icon>
+                } @else if (userCheckStatus()[player] === 'exists') {
+                  <mat-icon class="share-check-icon share-check-icon--ok" matTooltip="Uživatel nalezen">check_circle</mat-icon>
+                } @else if (userCheckStatus()[player] === 'not-found') {
+                  <mat-icon class="share-check-icon share-check-icon--warn" matTooltip="Uživatel nenalezen — mohl by existovat, ale dosud neuložil data">error_outline</mat-icon>
+                }
                 <span class="share-dialog__player-name">{{ player }}</span>
                 <button class="share-dialog__remove" type="button" (click)="removeSharePlayer(player)">✕</button>
               </div>
@@ -247,6 +264,7 @@ export class DmStoryTimelineComponent {
   shareDialogOpen   = signal(false);
   shareInput        = '';
   pendingSharedWith = signal<string[]>([]);
+  userCheckStatus   = signal<Record<string, 'checking' | 'exists' | 'not-found'>>({});
 
   // ── Tabs ───────────────────────────────────────────────────────────────────
   activeTab = signal<'shared' | 'own'>('own');
@@ -332,22 +350,37 @@ export class DmStoryTimelineComponent {
   // ── Share dialog ──────────────────────────────────────────────────────────
   openShareDialog(): void {
     this.pendingSharedWith.set([...this.sharedWith()]);
+    this.userCheckStatus.set({});
     this.shareInput = '';
     this.shareDialogOpen.set(true);
+    // Re-check all existing shared users
+    for (const u of this.sharedWith()) this._checkUser(u);
   }
 
   addSharePlayer(): void {
-    const name = this.shareInput.trim().toLowerCase();
+    const name = this.shareInput.trim();
     if (!name) return;
-    const current = this.auth.currentUser()?.username?.toLowerCase();
-    if (name === current) { this.snack.open('Nemůžeš pozvat sám sebe.', '✕', { verticalPosition: 'top', duration: 2500 }); return; }
-    if (this.pendingSharedWith().includes(name)) return;
+    const current = this.auth.currentUser()?.username;
+    if (name.toLowerCase() === current?.toLowerCase()) {
+      this.snack.open('Nemůžeš pozvat sám sebe.', '✕', { verticalPosition: 'top', duration: 2500 });
+      return;
+    }
+    if (this.pendingSharedWith().some(u => u.toLowerCase() === name.toLowerCase())) return;
     this.pendingSharedWith.update(list => [...list, name]);
     this.shareInput = '';
+    this._checkUser(name);
   }
 
   removeSharePlayer(player: string): void {
     this.pendingSharedWith.update(list => list.filter(p => p !== player));
+    this.userCheckStatus.update(s => { const n = { ...s }; delete n[player]; return n; });
+  }
+
+  private _checkUser(username: string): void {
+    this.userCheckStatus.update(s => ({ ...s, [username]: 'checking' }));
+    this.api.checkUserExists(username).subscribe(exists => {
+      this.userCheckStatus.update(s => ({ ...s, [username]: exists ? 'exists' : 'not-found' }));
+    });
   }
 
   saveSharing(): void {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -64,7 +64,7 @@ const ACL = '110,190,160'; // lighter teal
       mat-icon { font-size: 26px; width: 26px; height: 26px; color: #9e8f78; }
     }
     .header-subtitle { font-size: 11px; color: rgba(155,140,115,.45); letter-spacing: .05em; margin-top: 5px; font-family: sans-serif; font-style: italic; text-transform: none; }
-    .header-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+    .header-actions { display: flex; gap: 8px; align-items: end; justify-content: end; flex-wrap: wrap; margin-bottom: var(--spacing-4) }
 
     /* ── Buttons ─────────────────────────────────── */
     .btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -79,18 +79,8 @@ const ACL = '110,190,160'; // lighter teal
     }
 
     /* ── Filter / sort bar ───────────────────────── */
-    .filter-bar { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 10px; margin-bottom: 8px; }
-    .filter-tabs { display: flex; gap: 4px; flex-wrap: wrap; }
-    .filter-tab {
-      font-family: sans-serif; font-size: 10px; letter-spacing: .1em; text-transform: uppercase;
-      border: 1px solid rgba(255,255,255,.07); border-radius: 2px; background: transparent;
-      color: rgba(255,255,255,.3); padding: 4px 12px; cursor: pointer;
-      display: flex; align-items: center; gap: 6px; transition: background .15s, border-color .15s, color .15s;
-      &:hover { background: rgba(255,255,255,.05); color: rgba(255,255,255,.55); }
-      &--active { background: rgba(140,125,100,.14); border-color: rgba(155,140,115,.45); color: #d8cdb8; }
-    }
+    .filter-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
     .filter-count { background: rgba(255,255,255,.08); border-radius: 10px; padding: 0 6px; font-size: 9px; min-width: 18px; text-align: center; line-height: 16px; }
-    .filter-tab--active .filter-count { background: rgba(140,125,100,.25); }
     .sort-select {
       font-family: sans-serif; font-size: 10px; letter-spacing: .08em;
       background: rgba(140,125,100,.08); border: 1px solid rgba(155,140,115,.25); border-radius: 3px;
@@ -289,16 +279,14 @@ const ACL = '110,190,160'; // lighter teal
 
       <!-- Type filter + sort -->
       <div class="filter-bar">
-        <div class="filter-tabs">
-          <button class="filter-tab" [class.filter-tab--active]="filterType() === 'all'" (click)="filterType.set('all')">
-            Vše <span class="filter-count">{{ events().length }}</span>
+        <button class="pt-filter-btn" [class.active]="filterType() === 'all'" (click)="filterType.set('all')">
+          Vše <span class="filter-count">{{ events().length }}</span>
+        </button>
+        @for (t of typeKeys; track t) {
+          <button class="pt-filter-btn" [class.active]="filterType() === t" (click)="filterType.set(t)">
+            {{ typeMeta(t).label }}<span class="filter-count">{{ countByType()[t] ?? 0 }}</span>
           </button>
-          @for (t of typeKeys; track t) {
-            <button class="filter-tab" [class.filter-tab--active]="filterType() === t" (click)="filterType.set(t)">
-              {{ typeMeta(t).label }}<span class="filter-count">{{ countByType()[t] ?? 0 }}</span>
-            </button>
-          }
-        </div>
+        }
         <select class="sort-select" [ngModel]="sortOrder()" (ngModelChange)="sortOrder.set($event)">
           <option value="newest">Nejnovější první</option>
           <option value="oldest">Nejstarší první</option>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -94,8 +94,8 @@ import { StoryEventsListComponent } from './story-events-list.component';
     .share-dialog__player-name { font-family: sans-serif; font-size: 12px; color: rgba(220,200,150,.85); }
     .share-check-icon {
       font-size: 16px !important; width: 16px !important; height: 16px !important; flex-shrink: 0;
-      &--ok      { color: rgba(80,190,90,.85); }
-      &--warn    { color: rgba(210,80,70,.75); }
+      &--ok       { color: rgba(80,190,90,.85); }
+      &--warn     { color: rgba(155,155,155,.5); }
       &--checking { color: rgba(200,160,60,.5); animation: spin .8s linear infinite; }
     }
     @keyframes spin { to { transform: rotate(360deg); } }
@@ -225,7 +225,7 @@ import { StoryEventsListComponent } from './story-events-list.component';
                 } @else if (userCheckStatus()[player] === 'exists') {
                   <mat-icon class="share-check-icon share-check-icon--ok" matTooltip="Uživatel nalezen">check_circle</mat-icon>
                 } @else if (userCheckStatus()[player] === 'not-found') {
-                  <mat-icon class="share-check-icon share-check-icon--warn" matTooltip="Uživatel nenalezen — mohl by existovat, ale dosud neuložil data">error_outline</mat-icon>
+                  <mat-icon class="share-check-icon share-check-icon--warn" matTooltip="Uživatel dosud neuložil žádná data — sdílení proběhne správně, pokud je jméno napsáno přesně">help_outline</mat-icon>
                 }
                 <span class="share-dialog__player-name">{{ player }}</span>
                 <button class="share-dialog__remove" type="button" (click)="removeSharePlayer(player)">✕</button>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -1,103 +1,26 @@
 import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  effect,
-  ElementRef,
-  inject,
-  signal,
-  untracked,
-  viewChild,
+  ChangeDetectionStrategy, Component, computed, effect, inject, signal, untracked,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatIcon } from '@angular/material/icon';
-import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
-import { SpinnerOverlayComponent, RichTextareaComponent } from '@dn-d-servant/ui';
+import { SpinnerOverlayComponent } from '@dn-d-servant/ui';
 import { AuthService } from '@dn-d-servant/util';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { forkJoin } from 'rxjs';
 import { DmPageStore } from '../../dm-page.store';
 import { DmPageApiService } from '../../dm-page-api.service';
-import { StoryEvent, StoryEventType } from '../../dm-page-models';
-
-// ── Fuzzy-search helpers ──────────────────────────────────────────────────────
-function posNorm(s: string): string {
-  return s.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase();
-}
-
-function fuzzySubsequence(query: string, text: string): number[] | null {
-  const indices: number[] = [];
-  let ti = 0;
-  for (let qi = 0; qi < query.length; qi++) {
-    const ch = query[qi];
-    while (ti < text.length && text[ti] !== ch) ti++;
-    if (ti >= text.length) return null;
-    indices.push(ti);
-    ti++;
-  }
-  return indices;
-}
-
-function escHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
-function buildHighlightHtml(original: string, indices: number[]): string {
-  const matchSet = new Set(indices);
-  const parts: string[] = [];
-  let inSpan = false;
-  for (let i = 0; i < original.length; i++) {
-    const ch = escHtml(original[i]);
-    if (matchSet.has(i)) {
-      if (!inSpan) { parts.push('<span class="hl">'); inSpan = true; }
-      parts.push(ch);
-    } else {
-      if (inSpan) { parts.push('</span>'); inSpan = false; }
-      parts.push(ch);
-    }
-  }
-  if (inSpan) parts.push('</span>');
-  return parts.join('');
-}
-
-const TYPE_META: Record<StoryEventType, { label: string; icon: string; color: string; bg: string }> = {
-  world:     { label: 'Světová událost',  icon: 'public',       color: 'rgba(100,140,210,.9)', bg: 'rgba(70,110,190,.10)' },
-  campaign:  { label: 'Událost kampaně',  icon: 'auto_stories', color: 'rgba(210,175,55,.9)',  bg: 'rgba(190,155,40,.10)' },
-  character: { label: 'Událost postav',   icon: 'person',       color: 'rgba(60,185,150,.9)',  bg: 'rgba(40,160,120,.10)' },
-  other:     { label: 'Jiné',             icon: 'bookmark',     color: 'rgba(130,130,130,.8)', bg: 'rgba(100,100,100,.08)'},
-};
-
-const TYPE_ORDER: StoryEventType[] = ['world', 'campaign', 'character', 'other'];
-
-type FilterType = 'all' | StoryEventType;
-type SortOrder  = 'newest' | 'oldest';
-
-// Accent colour used for UI chrome (timeline line, buttons, borders)
-const AC  = '80,160,130'; // teal accent – RGB triplet
-const ACL = '110,190,160'; // lighter teal
+import { StoryEvent } from '../../dm-page-models';
+import { TYPE_ORDER, FilterType, SortOrder, parseTags } from './dm-story-timeline.types';
+import { StoryEventsListComponent } from './story-events-list.component';
 
 @Component({
   selector: 'dm-story-timeline',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, MatIcon, MatIconButton, MatTooltip, SpinnerOverlayComponent, RichTextareaComponent],
+  imports: [FormsModule, MatIcon, MatTooltip, SpinnerOverlayComponent, StoryEventsListComponent],
   host: { '(document:keydown.escape)': 'onEscape()' },
   styles: `
     :host { display: block; padding: 13px 0 20px; font-family: sans-serif; overflow: visible; }
-
-    /* ── Header ───────────────────────────────────── */
-    .header {
-      display: flex; align-items: flex-start; justify-content: space-between;
-      flex-wrap: wrap; gap: 14px; margin-bottom: 20px; padding-bottom: 14px;
-      border-bottom: 2px solid transparent;
-      border-image: linear-gradient(90deg, transparent, rgba(155,140,115,.5) 20%, rgba(175,160,130,.7) 50%, rgba(155,140,115,.5) 80%, transparent) 1;
-    }
-    .header-title { font-size: 22px; letter-spacing: .12em; text-transform: uppercase; color: #d8cdb8;
-      text-shadow: 0 0 18px rgba(155,140,115,.3); display: flex; align-items: center; gap: 10px;
-      mat-icon { font-size: 26px; width: 26px; height: 26px; color: #9e8f78; }
-    }
-    .header-subtitle { font-size: 11px; color: rgba(155,140,115,.45); letter-spacing: .05em; margin-top: 5px; font-family: sans-serif; font-style: italic; text-transform: none; }
-    .header-actions { display: flex; gap: 8px; align-items: end; justify-content: end; flex-wrap: wrap; margin-bottom: var(--spacing-4) }
 
     /* ── Buttons ─────────────────────────────────── */
     .btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
@@ -106,18 +29,16 @@ const ACL = '110,190,160'; // lighter teal
       mat-icon { font-size: 15px; width: 15px; height: 15px; }
       &:hover { background: rgba(140,125,100,.16); border-color: rgba(155,140,115,.6); color: #d8cdb8; }
     }
-    .btn-icon { padding: 6px 10px; }
     .btn-save { border-color: rgba(80,160,80,.35); color: rgba(100,200,100,.8); background: rgba(60,120,60,.08);
       &:hover { background: rgba(60,140,60,.18); border-color: rgba(80,180,80,.6); color: #80e080; }
     }
 
     /* ── pt-filter-btn icon support ─────────────── */
     .pt-filter-btn { display: inline-flex; align-items: center; gap: 5px;
-      mat-icon, .mat-icon { font-size: 14px; width: 14px; height: 14px; }
-    }
+      mat-icon, .mat-icon { font-size: 14px; width: 14px; height: 14px; } }
 
     /* ── Filter / sort bar ───────────────────────── */
-    .filter-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
+    .filter-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
     .filter-bar-spacer { flex: 1; }
     .filter-count { background: rgba(255,255,255,.08); border-radius: 10px; padding: 0 6px; font-size: 9px; min-width: 18px; text-align: center; line-height: 16px; }
     .sort-select {
@@ -128,7 +49,7 @@ const ACL = '110,190,160'; // lighter teal
     }
 
     /* ── Tag filter row ──────────────────────────── */
-    .tag-filter-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 20px; padding: 6px 0; }
+    .tag-filter-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 12px; padding: 6px 0; }
     .tag-filter-label { font-family: sans-serif; font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: rgba(155,140,115,.4); flex-shrink: 0; }
     .tag-filter-chip {
       font-family: sans-serif; font-size: 12px; padding: 3px 10px; border-radius: 10px; cursor: pointer; border: 1px solid; transition: background .12s, color .12s;
@@ -137,191 +58,21 @@ const ACL = '110,190,160'; // lighter teal
       &--active { background: rgba(140,125,100,.2); color: #d8cdb8; border-color: rgba(155,140,115,.6); }
     }
 
-    /* ── Timeline container ──────────────────────── */
-    .timeline { position: relative; padding-left: 48px; }
-    .timeline-line {
-      position: absolute; left: 16px; top: 0; bottom: 0; width: 2px;
-      background: linear-gradient(180deg, transparent, rgba(155,140,115,.28) 5%, rgba(155,140,115,.28) 95%, transparent);
+    /* ── Tabs (same style as Lektvary & Jedy) ────── */
+    .st-tabs { display: flex; align-items: center; gap: 0; margin-bottom: 20px; border-bottom: 1px solid rgba(200,160,60,.2); }
+    .st-tab {
+      padding: 10px 18px; font-size: 13px; font-weight: 600; color: #9a8a6a; cursor: pointer;
+      background: none; border: none; border-bottom: 2px solid transparent;
+      font-family: sans-serif; transition: all .15s; position: relative; top: 1px;
+      &:hover { color: #d4c9a0; }
+      &.active { color: #e8c96a; border-bottom-color: #e8c96a; }
     }
 
-    /* ── Timeline node ─────────────────────────── */
-    .tl-node {
-      position: absolute; left: -40px; top: 18px;
-      width: 28px; height: 28px; border-radius: 50%;
-      display: flex; align-items: center; justify-content: center;
-      border: 2px solid; background: rgba(14,12,8,.96);
-      mat-icon { font-size: 14px; width: 14px; height: 14px; }
-    }
-    /* ── Event card ──────────────────────────────── */
-    .event-card {
-      position: relative; border-radius: 3px; margin-bottom: 20px;
-      background: rgba(22,20,18,.97);
-      border: 1px solid rgba(200,160,60,.15);
-      box-shadow: 0 4px 20px rgba(0,0,0,.55);
-      transition: border-color .2s, box-shadow .2s; overflow: hidden;
-      &:hover { border-color: rgba(200,160,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65); }
-    }
-
-    /* ── Card header ────────────────────────────── */
-    .card-header { display: flex; align-items: center; gap: 8px; padding: 10px 12px 7px; flex-wrap: wrap; cursor: pointer; user-select: none; }
-    .type-badge {
-      font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
-      border-radius: 6px; padding: 4px 12px; cursor: pointer; border: 1px solid currentColor;
-      transition: filter .15s; white-space: nowrap; flex-shrink: 0;
-      &:hover { filter: brightness(1.18); }
-    }
-    .card-title-wrap { flex: 1; min-width: 0; overflow: hidden; }
-    .card-title {
-      font-family: sans-serif; font-size: 16px; font-weight: 500; color: #ddd5c5;
-      display: flex; align-items: center; gap: 10px; overflow: hidden;
-      &--placeholder { color: rgba(200,185,160,.2); font-style: italic; }
-    }
-    .card-title-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex-shrink: 1; min-width: 0; }
-    .card-date     { font-family: sans-serif; font-size: 9px; color: rgba(175,160,135,.42); letter-spacing: .04em; white-space: nowrap; flex-shrink: 0; }
-    .card-location { font-family: sans-serif; font-size: 10px; color: rgba(175,160,135,.35); letter-spacing: .03em;
-      display: flex; align-items: center; gap: 3px; white-space: nowrap; flex-shrink: 0;
-      mat-icon { font-size: 11px; width: 11px; height: 11px; }
-    }
-    .card-actions { display: flex; gap: 2px; align-items: center; flex-shrink: 0; }
-    .card-action-btn {
-      background: none; border: none; cursor: pointer; color: rgba(155,140,115,.38); padding: 4px; border-radius: 3px;
-      transition: color .15s, background .15s; display: flex; align-items: center;
-      mat-icon { font-size: 16px; width: 16px; height: 16px; }
-      &:hover { color: rgba(185,170,140,.8); background: rgba(140,125,100,.1); }
-      &--danger:hover { color: rgba(220,80,70,.8); background: rgba(200,60,50,.1); }
-    }
-    .expand-chevron { transition: transform .2s; mat-icon { font-size: 16px; width: 16px; height: 16px; color: rgba(155,140,115,.38); } }
-    .expand-chevron--open { transform: rotate(180deg); }
-
-    /* ── Tag chips (collapsed view) ─────────────── */
-    .tag-list { display: flex; gap: 5px; flex-wrap: wrap; padding: 0 12px 8px; }
-    .tag-chip {
-      font-family: sans-serif; font-size: 11px; padding: 3px 9px; border-radius: 10px;
-      background: rgba(140,125,100,.1); border: 1px solid rgba(155,140,115,.2); color: rgba(185,170,140,.7);
-      letter-spacing: .03em; display: inline-flex; align-items: center; gap: 4px;
-    }
-
-    /* ── Expanded body ───────────────────────────── */
-    .card-body { padding: 0 12px 14px; display: flex; flex-direction: column; gap: 10px; }
-    .field-row { display: flex; gap: 10px; flex-wrap: wrap; }
-    .field-group { display: flex; flex-direction: column; gap: 4px; flex: 1; min-width: 180px; }
-    .field-label { font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: rgba(155,140,115,.38); }
-    .field-input {
-      background: rgba(140,125,100,.06); border: 1px solid rgba(155,140,115,.16); border-radius: 3px;
-      color: rgba(220,210,190,.85); font-family: sans-serif; font-size: 13px; padding: 6px 10px; width: 100%; box-sizing: border-box;
-      &:focus { outline: none; border-color: rgba(155,140,115,.38); background: rgba(140,125,100,.1); }
-      &::placeholder { color: rgba(155,140,115,.22); }
-    }
-    .rt-label { font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: rgba(155,140,115,.38); margin-bottom: 3px; }
-    .rt-wrap { position: relative; height: 160px; background: rgba(140,125,100,.05); border: 1px solid rgba(155,140,115,.13); border-radius: 3px; overflow: visible; margin-top: 44px; }
-
-    /* ── Tag input (edit mode) ───────────────────── */
-    .tag-input-wrap {
-      display: flex; flex-wrap: wrap; gap: 4px; align-items: center;
-      background: rgba(140,125,100,.06); border: 1px solid rgba(155,140,115,.16); border-radius: 3px;
-      padding: 5px 8px; min-height: 36px; cursor: text;
-      &:focus-within { border-color: rgba(155,140,115,.38); background: rgba(140,125,100,.1); }
-    }
-    .tag-chip--removable {
-      background: rgba(140,125,100,.14); border-color: rgba(155,140,115,.3); color: #d8cdb8;
-      padding-right: 4px;
-    }
-    .tag-chip--preview {
-      background: rgba(140,125,100,.08); border: 1px dashed rgba(155,140,115,.32);
-      color: rgba(185,170,140,.52); font-style: italic;
-    }
-    .tag-chip-remove {
-      background: none; border: none; cursor: pointer; color: rgba(185,170,140,.55); font-size: 14px; line-height: 1;
-      padding: 2px 4px; display: flex; align-items: center; transition: color .12s, background .12s; border-radius: 3px;
-      &:hover { color: rgba(220,80,70,.9); background: rgba(200,50,40,.15); }
-    }
-
-    /* ── Tag suggestion dropdown ─────────────────── */
-    .tag-field-wrap { position: relative; }
-    .tag-suggestions {
-      position: absolute; top: calc(100% + 2px); left: 0; right: 0; z-index: 200;
-      background: rgba(18,14,8,.98);
-      border: 1px solid rgba(155,140,115,.35);
-      border-radius: 4px;
-      max-height: 180px; overflow-y: auto;
-      box-shadow: 0 6px 20px rgba(0,0,0,.7);
-    }
-    .tag-suggestion-item {
-      display: block; width: 100%; text-align: left; padding: 7px 12px;
-      background: none; border: none; border-bottom: 1px solid rgba(155,140,115,.08);
-      color: rgba(220,210,190,.75); font-size: 11px; font-family: sans-serif; cursor: pointer;
-      transition: background .1s, color .1s;
-      &:last-child { border-bottom: none; }
-      &:hover, &--active { background: rgba(155,140,115,.12); color: #d8cdb8; }
-    }
-    ::ng-deep .tag-suggestions .hl { color: rgba(210,175,55,.95); font-weight: 700; }
-    .tag-text-input {
-      background: transparent; border: none; outline: none; color: rgba(220,210,190,.85);
-      font-family: sans-serif; font-size: 12px; min-width: 100px; flex: 1;
-      &::placeholder { color: rgba(155,140,115,.22); }
-    }
-
-    /* ── DM notes ────────────────────────────────── */
-    .dm-section-toggle { display: flex; align-items: center; gap: 6px; cursor: pointer; user-select: none; padding: 4px 0; border: none; background: none; color: rgba(200,60,60,.5); font-family: sans-serif; font-size: 9px; letter-spacing: .12em; text-transform: uppercase;
-      mat-icon { font-size: 13px; width: 13px; height: 13px; }
-      &:hover { color: rgba(220,80,80,.8); }
-    }
-    .dm-rt-wrap { position: relative; height: 90px; background: rgba(200,60,60,.05); border: 1px solid rgba(200,60,60,.12); border-radius: 3px; overflow: hidden; margin-top: 4px; }
-
-    /* ── Image zone ──────────────────────────────── */
-    .img-zone {
-      border: 1px dashed rgba(155,140,115,.18); border-radius: 3px; background: rgba(140,125,100,.03);
-      min-height: 56px; display: flex; align-items: center; justify-content: center;
-      cursor: pointer; transition: border-color .15s, background .15s; position: relative; overflow: hidden;
-      &:hover, &--dragover { border-color: rgba(155,140,115,.42); background: rgba(140,125,100,.08); }
-    }
-    .img-placeholder { display: flex; flex-direction: column; align-items: center; gap: 4px; color: rgba(155,140,115,.28); font-size: 10px; letter-spacing: .06em;
-      mat-icon { font-size: 22px; width: 22px; height: 22px; }
-    }
-    .img-preview { width: 100%; max-height: 200px; object-fit: contain; display: block; cursor: zoom-in; }
-    .img-remove-btn { position: absolute; top: 4px; right: 4px; background: rgba(0,0,0,.6); border: none; border-radius: 50%; width: 22px; height: 22px; cursor: pointer; color: rgba(255,100,80,.8); display: flex; align-items: center; justify-content: center;
-      mat-icon { font-size: 14px; width: 14px; height: 14px; }
-      &:hover { background: rgba(200,40,30,.4); }
-    }
-    .img-file-input { display: none; }
-
-    /* ── Empty state ─────────────────────────────── */
-    .empty-state { text-align: center; padding: 70px 20px; color: rgba(255,255,255,.1); font-size: 13px; letter-spacing: .1em;
-      mat-icon { font-size: 54px; width: 54px; height: 54px; display: block; margin: 0 auto 16px; color: rgba(155,140,115,.1); }
-    }
-
-    /* ── Confirm dialog ──────────────────────────── */
-    .confirm-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.72); display: flex; align-items: center; justify-content: center; z-index: 1100; backdrop-filter: blur(3px); }
-    .confirm-dialog { background: linear-gradient(160deg,rgba(22,18,12,.99),rgba(14,11,7,.99)); border: 1px solid rgba(200,80,60,.4); border-radius: 6px; padding: 28px 32px; max-width: 360px; width: 90vw; text-align: center; }
-    .confirm-icon { color: rgba(220,60,50,.7); mat-icon { font-size: 36px; width: 36px; height: 36px; } }
-    .confirm-title { font-size: 16px; letter-spacing: .1em; color: #f0b0b0; margin: 10px 0 6px; text-transform: uppercase; }
-    .confirm-msg { font-size: 12px; color: rgba(220,180,180,.6); font-family: sans-serif; }
-    .confirm-rule { height: 1px; background: linear-gradient(90deg,transparent,rgba(200,80,60,.3),transparent); margin: 16px 0; }
-    .confirm-actions { display: flex; gap: 10px; justify-content: center; }
-    .confirm-btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase; padding: 7px 20px; border-radius: 3px; cursor: pointer; border: 1px solid; }
-    .confirm-cancel { color: rgba(180,160,140,.7); border-color: rgba(180,160,140,.25); background: transparent; &:hover { background: rgba(180,160,140,.08); } }
-    .confirm-delete { color: rgba(220,80,70,.85); border-color: rgba(200,60,50,.4); background: rgba(200,50,40,.1); &:hover { background: rgba(200,50,40,.2); } }
-
-    /* ── Image preview modal ─────────────────────── */
-    .preview-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.88); display: flex; align-items: center; justify-content: center; z-index: 1200; backdrop-filter: blur(6px); }
-    .preview-container { position: relative; max-width: 90vw; max-height: 90vh; display: flex; flex-direction: column; align-items: center; gap: 12px; }
-    .preview-close { position: absolute; top: -14px; right: -14px; color: rgba(185,170,140,.6) !important; }
-    .preview-title { font-family: sans-serif; font-size: 14px; color: #ddd5c5; text-align: center; }
-    .preview-frame { border: 1px solid rgba(155,140,115,.28); border-radius: 4px; overflow: hidden; img { max-width: 85vw; max-height: 80vh; display: block; } }
-    .preview-hint { font-size: 10px; color: rgba(155,140,115,.28); letter-spacing: .06em; }
-
-    /* ── Read-only banner ───────────────────────── */
-    .readonly-banner {
-      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
-      margin-bottom: 16px; padding: 10px 16px;
-      background: rgba(100,140,210,.08);
-      border: 1px solid rgba(100,140,210,.25);
-      border-radius: 4px;
-      font-family: sans-serif; font-size: 12px; color: rgba(160,190,240,.8);
-      mat-icon { font-size: 16px; width: 16px; height: 16px; flex-shrink: 0; }
-    }
-    .readonly-banner__owner {
-      color: #a8c4f0; font-weight: 600;
+    /* ── No-shared placeholder ───────────────────── */
+    .no-shared {
+      text-align: center; padding: 60px 20px;
+      color: rgba(155,140,115,.35); font-family: sans-serif; font-size: 13px; letter-spacing: .06em;
+      mat-icon { font-size: 48px; width: 48px; height: 48px; display: block; margin: 0 auto 14px; color: rgba(155,140,115,.15); }
     }
 
     /* ── Share dialog ───────────────────────────── */
@@ -356,18 +107,21 @@ const ACL = '110,190,160'; // lighter teal
       &:hover { color: rgba(220,80,70,.9); background: rgba(200,50,40,.12); }
     }
     .share-dialog__actions { display: flex; gap: 8px; justify-content: flex-end; padding-top: 4px; border-top: 1px solid rgba(200,160,60,.12); margin-top: 4px; }
+
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+    @keyframes scaleIn { from { transform: scale(.92); opacity: 0; } to { transform: scale(1); opacity: 1; } }
   `,
   template: `
     <spinner-overlay [diameter]="60" [showSpinner]="store.loading()">
 
-      <!-- Filter + actions row -->
+      <!-- Filter + actions bar -->
       <div class="filter-bar">
         <button class="pt-filter-btn" [class.active]="filterType() === 'all'" (click)="filterType.set('all')">
-          Vše <span class="filter-count">{{ events().length }}</span>
+          Vše <span class="filter-count">{{ activeEvents().length }}</span>
         </button>
         @for (t of typeKeys; track t) {
           <button class="pt-filter-btn" [class.active]="filterType() === t" (click)="filterType.set(t)">
-            {{ typeMeta(t).label }}<span class="filter-count">{{ countByType()[t] ?? 0 }}</span>
+            {{ typeLabel(t) }}<span class="filter-count">{{ countByType()[t] ?? 0 }}</span>
           </button>
         }
         <select class="sort-select" [ngModel]="sortOrder()" (ngModelChange)="sortOrder.set($event)">
@@ -375,25 +129,14 @@ const ACL = '110,190,160'; // lighter teal
           <option value="oldest">Nejstarší první</option>
         </select>
         <span class="filter-bar-spacer"></span>
-        <button class="pt-filter-btn" (click)="toggleAllExpanded()" [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozbalit vše'">
-          <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
-        </button>
-        @if (!isReadOnly()) {
+        @if (activeTab() === 'own') {
           <button class="pt-filter-btn" (click)="addEvent()"><mat-icon>add</mat-icon> Přidat událost</button>
-          <button class="pt-filter-btn" (click)="openShareDialog()" matTooltip="Sdílet s hráči">
+          <button class="pt-filter-btn" (click)="openShareDialog()" matTooltip="Sdílet moje události s hráči">
             <mat-icon>share</mat-icon> Sdílet
           </button>
           <button class="btn btn-save" (click)="save()"><mat-icon>save</mat-icon> Uložit</button>
         }
       </div>
-
-      <!-- Read-only banner -->
-      @if (isReadOnly()) {
-        <div class="readonly-banner">
-          <mat-icon>visibility</mat-icon>
-          Zobrazuješ příběhové události sdílené hráčem <span class="readonly-banner__owner">{{ ownerUsername() }}</span>. Obsah je pouze pro čtení.
-        </div>
-      }
 
       <!-- Tag filter row -->
       @if (allTags().length > 0) {
@@ -406,148 +149,46 @@ const ACL = '110,190,160'; // lighter teal
         </div>
       }
 
-      <!-- Timeline -->
-      <div class="timeline">
-        <div class="timeline-line"></div>
-
-        @if (filtered().length === 0) {
-          <div class="empty-state">
-            <mat-icon>auto_stories</mat-icon>
-            @if (events().length === 0) { Ještě žádné události — přidejte první kapitolu příběhu }
-            @else { Žádné události neodpovídají filtru }
-          </div>
-        }
-
-        @for (item of filtered(); track item.event.id) {
-          <div class="event-card">
-
-            <div class="tl-node"
-              [style.border-color]="typeMeta(item.event.type).color"
-              [style.color]="typeMeta(item.event.type).color">
-              <mat-icon>{{ typeMeta(item.event.type).icon }}</mat-icon>
-            </div>
-
-            <!-- Card header -->
-            <div class="card-header" (click)="toggleExpand(item.event.id)">
-              <span class="type-badge" [style.color]="typeMeta(item.event.type).color" [style.background]="typeMeta(item.event.type).bg"
-                (click)="$event.stopPropagation(); !isReadOnly() && cycleType(item.idx)"
-                [matTooltip]="isReadOnly() ? '' : 'Kliknutím změnit typ'">{{ typeMeta(item.event.type).label }}</span>
-
-              <div class="card-title-wrap">
-                <div class="card-title" [class.card-title--placeholder]="!item.event.title">
-                  <span class="card-title-text">{{ item.event.title || 'Bez názvu…' }}</span>
-                  @if (item.event.location) {
-                    <span class="card-location"><mat-icon>location_on</mat-icon>{{ item.event.location }}</span>
-                  }
-                </div>
-              </div>
-
-              @if (item.event.realDate) {
-                <span class="card-date">{{ item.event.realDate }}</span>
-              }
-
-              @if (!isReadOnly()) {
-                <div class="card-actions" (click)="$event.stopPropagation()">
-                  <button class="card-action-btn card-action-btn--danger" (click)="askDelete(item.idx)" matTooltip="Smazat událost">
-                    <mat-icon>delete_outline</mat-icon>
-                  </button>
-                </div>
-              }
-              <div class="expand-chevron" [class.expand-chevron--open]="expandedIds().has(item.event.id)">
-                <mat-icon>expand_more</mat-icon>
-              </div>
-            </div>
-
-            <!-- Tags (collapsed view) -->
-            @if (parseTags(item.event.tags).length > 0 && !expandedIds().has(item.event.id)) {
-              <div class="tag-list">
-                @for (tag of parseTags(item.event.tags); track tag) {
-                  <span class="tag-chip">{{ tag }}</span>
-                }
-              </div>
-            }
-
-            <!-- Expanded body -->
-            @if (expandedIds().has(item.event.id)) {
-              <div class="card-body">
-
-                <!-- Row 1: title -->
-                <div class="field-row">
-                  <div class="field-group" style="flex:1;min-width:200px">
-                    <div class="field-label">Název události</div>
-                    <input class="field-input" [(ngModel)]="events()[item.idx].title" placeholder="Název…" [disabled]="isReadOnly()" />
-                  </div>
-                </div>
-
-                <!-- Row 2: location + tag chip input -->
-                <div class="field-row">
-                  <div class="field-group">
-                    <div class="field-label">Místo</div>
-                    <input class="field-input" [(ngModel)]="events()[item.idx].location" placeholder="Město, dungeon, les…" [disabled]="isReadOnly()" />
-                  </div>
-                  <div class="field-group" style="flex:2">
-                    <div class="field-label">Štítky</div>
-                    @if (isReadOnly()) {
-                      <div class="tag-input-wrap" style="pointer-events:none;opacity:.7;">
-                        @for (tag of parseTags(events()[item.idx].tags); track tag) {
-                          <span class="tag-chip tag-chip--removable">{{ tag }}</span>
-                        }
-                      </div>
-                    }
-                    @if (!isReadOnly()) {
-                    <div class="tag-field-wrap">
-                      <div class="tag-input-wrap" (click)="focusTagInput(item.event.id)">
-                        @for (tag of parseTags(events()[item.idx].tags); track tag) {
-                          <span class="tag-chip tag-chip--removable">
-                            {{ tag }}
-                            <button class="tag-chip-remove" type="button" (click)="$event.stopPropagation(); removeTag(item.idx, tag)">×</button>
-                          </span>
-                        }
-                        <input
-                          class="tag-text-input"
-                          [id]="'tag-input-' + item.event.id"
-                          [ngModel]="getTagInput(item.event.id)"
-                          (ngModelChange)="setTagInput(item.event.id, $event)"
-                          (keydown.enter)="$event.preventDefault(); onTagEnter(item.idx, item.event.id)"
-                          (keydown.space)="$event.preventDefault(); addTagFromInput(item.idx)"
-                          (keydown.arrowdown)="$event.preventDefault(); navigateSuggestions(item.event.id, 1)"
-                          (keydown.arrowup)="$event.preventDefault(); navigateSuggestions(item.event.id, -1)"
-                          (keydown.escape)="setActiveSuggIdx(item.event.id, -1)"
-                          (blur)="onTagBlur(item.idx)"
-                          placeholder="{{ parseTags(events()[item.idx].tags).length ? '' : 'Přidat štítek…' }}"
-                        />
-                      </div>
-                      @if (getTagSuggestions(item.event.id).length > 0) {
-                        <div class="tag-suggestions">
-                          @for (sugg of getTagSuggestions(item.event.id); track sugg.tag; let si = $index) {
-                            <button
-                              class="tag-suggestion-item"
-                              [class.tag-suggestion-item--active]="getActiveSuggIdx(item.event.id) === si"
-                              type="button"
-                              (mousedown)="$event.preventDefault()"
-                              (click)="selectSuggestion(item.idx, sugg.tag)"
-                            ><span [innerHTML]="sugg.html"></span></button>
-                          }
-                        </div>
-                      }
-                    </div>
-                    }
-                  </div>
-                </div>
-
-                <!-- Summary -->
-                <div>
-                  <div class="rt-label">Shrnutí události</div>
-                  <div class="rt-wrap" style="margin-top: 5px;">
-                    <rich-textarea [(ngModel)]="events()[item.idx].summary" style="position:absolute;top:0;left:0;width:100%;height:100%;"></rich-textarea>
-                  </div>
-                </div>
-
-              </div>
-            }
-          </div>
-        }
+      <!-- Tabs -->
+      <div class="st-tabs">
+        <button class="st-tab" [class.active]="activeTab() === 'shared'" (click)="activeTab.set('shared')">
+          Sdílené události
+        </button>
+        <button class="st-tab" [class.active]="activeTab() === 'own'" (click)="activeTab.set('own')">
+          Moje události
+        </button>
       </div>
+
+      <!-- Shared tab content -->
+      @if (activeTab() === 'shared') {
+        @if (ownerUsername()) {
+          <story-events-list
+            [eventsRef]="sharedEvents"
+            [isReadOnly]="true"
+            [filterType]="filterType()"
+            [filterTag]="filterTag()"
+            [sortOrder]="sortOrder()"
+          />
+        } @else {
+          <div class="no-shared">
+            <mat-icon>group</mat-icon>
+            Nikdo s tebou zatím nesdílí příběhové události.<br>Přepni na záložku <strong>Moje události</strong> a začni psát.
+          </div>
+        }
+      }
+
+      <!-- Own tab content -->
+      @if (activeTab() === 'own') {
+        <story-events-list
+          [eventsRef]="ownEvents"
+          [isReadOnly]="false"
+          [filterType]="filterType()"
+          [filterTag]="filterTag()"
+          [sortOrder]="sortOrder()"
+          [autoExpandId]="newEventId()"
+        />
+      }
+
     </spinner-overlay>
 
     <!-- Share dialog -->
@@ -555,16 +196,11 @@ const ACL = '110,190,160'; // lighter teal
       <div class="share-backdrop" (click)="shareDialogOpen.set(false)">
         <div class="share-dialog" (click)="$event.stopPropagation()">
           <div class="share-dialog__title">Sdílet příběhové události</div>
-          <div class="share-dialog__desc">Pozvaní hráči uvidí události v režimu pouze pro čtení pod svým přihlášením.</div>
+          <div class="share-dialog__desc">Pozvaní hráči uvidí tvoje události v režimu pouze pro čtení.</div>
 
           <div class="share-dialog__section-label">Přidat hráče</div>
           <div class="share-dialog__input-row">
-            <input
-              class="share-dialog__input"
-              [(ngModel)]="shareInput"
-              placeholder="Uživatelské jméno hráče…"
-              (keydown.enter)="addSharePlayer()"
-            />
+            <input class="share-dialog__input" [(ngModel)]="shareInput" placeholder="Uživatelské jméno hráče…" (keydown.enter)="addSharePlayer()" />
             <button class="pt-filter-btn" type="button" (click)="addSharePlayer()">
               <mat-icon>add</mat-icon> Přidat
             </button>
@@ -578,7 +214,7 @@ const ACL = '110,190,160'; // lighter teal
             @for (player of pendingSharedWith(); track player) {
               <div class="share-dialog__player">
                 <span class="share-dialog__player-name">{{ player }}</span>
-                <button class="share-dialog__remove" type="button" (click)="removeSharePlayer(player)" title="Odebrat">✕</button>
+                <button class="share-dialog__remove" type="button" (click)="removeSharePlayer(player)">✕</button>
               </div>
             }
           </div>
@@ -592,128 +228,86 @@ const ACL = '110,190,160'; // lighter teal
         </div>
       </div>
     }
-
-    <input #globalFile type="file" accept="image/*" class="img-file-input" (change)="onImageSelected($event)" />
-
-    @if (confirmIdx() !== null) {
-      <div class="confirm-backdrop" (click)="cancelDelete()">
-        <div class="confirm-dialog" (click)="$event.stopPropagation()">
-          <div class="confirm-icon"><mat-icon>delete_forever</mat-icon></div>
-          <div class="confirm-title">Smazat událost?</div>
-          <div class="confirm-msg">
-            Opravdu smazat
-            @if (events()[confirmIdx()!]?.title) { <strong>„{{ events()[confirmIdx()!].title }}"</strong> } @else { <strong>tuto událost</strong> }?
-          </div>
-          <div class="confirm-rule"></div>
-          <div class="confirm-actions">
-            <button class="confirm-btn confirm-cancel" (click)="cancelDelete()">Zrušit</button>
-            <button class="confirm-btn confirm-delete" (click)="confirmDelete()">Smazat</button>
-          </div>
-        </div>
-      </div>
-    }
-
-    @if (previewEvent()) {
-      <div class="preview-backdrop" (click)="closePreview()">
-        <div class="preview-container" (click)="$event.stopPropagation()">
-          <button mat-icon-button class="preview-close" (click)="closePreview()"><mat-icon>close</mat-icon></button>
-          @if (previewEvent()!.title) { <div class="preview-title">{{ previewEvent()!.title }}</div> }
-          <div class="preview-frame"><img [src]="'data:image/png;base64,' + previewEvent()!.imageBase64" [alt]="previewEvent()!.title" /></div>
-          <div class="preview-hint">Klikni mimo nebo Esc pro zavření</div>
-        </div>
-      </div>
-    }
   `,
 })
 export class DmStoryTimelineComponent {
-  readonly store   = inject(DmPageStore);
+  readonly store = inject(DmPageStore);
   private readonly auth  = inject(AuthService);
   private readonly api   = inject(DmPageApiService);
   private readonly snack = inject(MatSnackBar);
 
-  events      = signal<StoryEvent[]>([]);
-  filterType  = signal<FilterType>('all');
-  filterTag   = signal<string | null>(null);
-  sortOrder   = signal<SortOrder>('newest');
-  expandedIds = signal<Set<string>>(new Set());
-  dmNotesOpen = signal<Set<string>>(new Set());
-  confirmIdx  = signal<number | null>(null);
-  dragOver    = signal<number | null>(null);
-  previewEvent = signal<StoryEvent | null>(null);
+  // ── Events state ──────────────────────────────────────────────────────────
+  ownEvents    = signal<StoryEvent[]>([]);
+  sharedEvents = signal<StoryEvent[]>([]);
+  newEventId   = signal<string | null>(null);
 
   // ── Sharing ────────────────────────────────────────────────────────────────
-  /** Username of the owner whose data we're viewing; null = viewing own data */
-  ownerUsername = signal<string | null>(null);
-  readonly isReadOnly = computed(() => this.ownerUsername() !== null);
-  /** sharedWith list from the loaded timeline */
-  sharedWith = signal<string[]>([]);
-  shareDialogOpen = signal(false);
-  shareInput = '';
+  ownerUsername     = signal<string | null>(null);
+  sharedWith        = signal<string[]>([]);
+  shareDialogOpen   = signal(false);
+  shareInput        = '';
   pendingSharedWith = signal<string[]>([]);
 
-  /** Per-event current tag text being typed */
-  private tagInputMap = signal<Record<string, string>>({});
+  // ── Tabs ───────────────────────────────────────────────────────────────────
+  activeTab = signal<'shared' | 'own'>('own');
 
-  private pendingFileIdx = signal<number | null>(null);
-  private readonly globalFile = viewChild<ElementRef<HTMLInputElement>>('globalFile');
+  // ── Filters (shared across both tabs) ─────────────────────────────────────
+  filterType = signal<FilterType>('all');
+  filterTag  = signal<string | null>(null);
+  sortOrder  = signal<SortOrder>('newest');
 
   readonly typeKeys = TYPE_ORDER;
 
-  readonly countByType = computed((): Record<StoryEventType, number> => {
-    const all = this.events();
-    const r = {} as Record<StoryEventType, number>;
-    for (const t of TYPE_ORDER) r[t] = all.filter(e => e.type === t).length;
-    return r;
-  });
+  readonly activeEvents = computed(() =>
+    this.activeTab() === 'shared' ? this.sharedEvents() : this.ownEvents()
+  );
 
   readonly allTags = computed((): string[] => {
     const set = new Set<string>();
-    for (const e of this.events()) for (const t of this.parseTags(e.tags)) set.add(t);
+    for (const e of this.activeEvents()) for (const t of parseTags(e.tags)) set.add(t);
     return [...set].sort();
   });
 
-  readonly filtered = computed(() => {
-    const ft  = this.filterType();
-    const tag = this.filterTag();
-    const asc = this.sortOrder() === 'oldest';
-    return this.events()
-      .map((event, idx) => ({ event, idx }))
-      .filter(({ event }) => {
-        if (ft !== 'all' && event.type !== ft) return false;
-        if (tag && !this.parseTags(event.tags).includes(tag)) return false;
-        return true;
-      })
-      .sort((a, b) => {
-        const da = a.event.realDate || '0';
-        const db = b.event.realDate || '0';
-        return asc ? da.localeCompare(db) : db.localeCompare(da);
-      });
+  readonly countByType = computed(() => {
+    const events = this.activeEvents();
+    const r: Record<string, number> = {};
+    for (const t of TYPE_ORDER) r[t] = events.filter(e => e.type === t).length;
+    return r;
   });
 
   constructor() {
-    // When store data arrives, populate events + sharedWith
+    // Own data from store → ownEvents
     effect(() => {
       const data = this.store.dmStoryTimeline();
       untracked(() => {
         if (data?.events) {
-          this.events.set(data.events.map(e => ({ ...e })));
+          this.ownEvents.set(data.events.map(e => ({ ...e })));
           this.sharedWith.set(data.sharedWith ?? []);
         }
       });
     });
 
-    // On auth, check invitation then load appropriate data
+    // On auth: check invitation, load own data, load shared data if invited
     effect(() => {
       const username = this.auth.currentUser()?.username;
       untracked(() => {
         if (!username) return;
+        // Always load own data via store
+        this.store.loadDmStoryTimeline(username);
+        // Check for invitation
         this.api.getTimelineInvitation(username).subscribe(inv => {
           if (inv?.ownerUsername && inv.ownerUsername !== username) {
             this.ownerUsername.set(inv.ownerUsername);
-            this.store.loadDmStoryTimeline(inv.ownerUsername);
+            this.activeTab.set('shared');
+            // Load shared data directly (bypasses store to avoid collision)
+            this.api.getDmStoryTimeline(inv.ownerUsername).subscribe(sharedData => {
+              if (sharedData?.events) {
+                this.sharedEvents.set(sharedData.events.map(e => ({ ...e })));
+              }
+            });
           } else {
             this.ownerUsername.set(null);
-            this.store.loadDmStoryTimeline(username);
+            this.activeTab.set('own');
           }
         });
       });
@@ -722,114 +316,17 @@ export class DmStoryTimelineComponent {
 
   addEvent(): void {
     const id = crypto.randomUUID();
-    this.events.update(list => [{ id, title: '', inGameDate: '', realDate: new Date().toISOString().split('T')[0], type: 'other', summary: '', dmNotes: '', imageBase64: null, location: '', tags: '' } as StoryEvent, ...list]);
-    this.expandedIds.update(s => new Set([...s, id]));
-  }
-
-  readonly allExpanded = computed(() =>
-    this.events().length > 0 && this.events().every(e => this.expandedIds().has(e.id))
-  );
-
-  toggleExpand(id: string): void  { this.expandedIds.update(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; }); }
-  expandAll():  void               { this.expandedIds.set(new Set(this.events().map(e => e.id))); }
-  collapseAll(): void              { this.expandedIds.set(new Set()); }
-  toggleAllExpanded(): void        { this.allExpanded() ? this.collapseAll() : this.expandAll(); }
-  toggleDmNotes(id: string): void  { this.dmNotesOpen.update(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; }); }
-
-  cycleType(idx: number): void {
-    this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, type: TYPE_ORDER[(TYPE_ORDER.indexOf(e.type) + 1) % TYPE_ORDER.length] }));
-  }
-  // ── Tags ──────────────────────────────────────────────────────────────────
-  private readonly activeSuggIdxMap = signal<Record<string, number>>({});
-
-  getTagInput(id: string): string            { return this.tagInputMap()[id] ?? ''; }
-  setTagInput(id: string, val: string): void { this.tagInputMap.update(m => ({ ...m, [id]: val })); this.setActiveSuggIdx(id, -1); }
-  focusTagInput(id: string): void            { document.getElementById('tag-input-' + id)?.focus(); }
-
-  getActiveSuggIdx(id: string): number            { return this.activeSuggIdxMap()[id] ?? -1; }
-  setActiveSuggIdx(id: string, n: number): void   { this.activeSuggIdxMap.update(m => ({ ...m, [id]: n })); }
-
-  getTagSuggestions(eventId: string): Array<{ tag: string; html: string }> {
-    const rawQuery = this.getTagInput(eventId).trim();
-    if (!rawQuery) return [];
-    const query = posNorm(rawQuery);
-    const existingSet = new Set(this.parseTags(this.events().find(e => e.id === eventId)?.tags ?? ''));
-    return this.allTags()
-      .filter(tag => !existingSet.has(tag))
-      .map(tag => {
-        const indices = fuzzySubsequence(query, posNorm(tag));
-        if (!indices) return null;
-        return { tag, html: buildHighlightHtml(tag, indices) };
-      })
-      .filter((x): x is { tag: string; html: string } => x !== null);
-  }
-
-  selectSuggestion(idx: number, tag: string): void {
-    const id = this.events()[idx]?.id; if (!id) return;
-    const existing = this.parseTags(this.events()[idx].tags);
-    if (!existing.includes(tag)) {
-      this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...this.parseTags(e.tags), tag].join(' ') }));
-    }
-    this.setTagInput(id, '');
-    this.setActiveSuggIdx(id, -1);
-    document.getElementById('tag-input-' + id)?.focus();
-  }
-
-  navigateSuggestions(id: string, dir: 1 | -1): void {
-    const len = this.getTagSuggestions(id).length;
-    if (!len) return;
-    const next = Math.max(-1, Math.min(len - 1, this.getActiveSuggIdx(id) + dir));
-    this.setActiveSuggIdx(id, next);
-  }
-
-  onTagEnter(idx: number, id: string): void {
-    const activeIdx = this.getActiveSuggIdx(id);
-    const suggestions = this.getTagSuggestions(id);
-    if (activeIdx >= 0 && activeIdx < suggestions.length) {
-      this.selectSuggestion(idx, suggestions[activeIdx].tag);
-    } else {
-      this.addTagFromInput(idx);
-    }
-  }
-
-  onTagBlur(idx: number): void {
-    const id = this.events()[idx]?.id; if (!id) return;
-    this.setActiveSuggIdx(id, -1);
-    const val = this.getTagInput(id).trim(); if (!val) return;
-    const existing = this.parseTags(this.events()[idx].tags);
-    if (!existing.includes(val)) {
-      this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...existing, val].join(' ') }));
-    }
-    this.setTagInput(id, '');
-  }
-
-  addTagFromInput(idx: number): void {
-    const id  = this.events()[idx]?.id; if (!id) return;
-    const val = this.getTagInput(id).trim(); if (!val) return;
-    const existing = this.parseTags(this.events()[idx].tags);
-    if (!existing.includes(val)) {
-      this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...existing, val].join(' ') }));
-    }
-    this.setTagInput(id, '');
-  }
-  removeTag(idx: number, tag: string): void {
-    this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: this.parseTags(e.tags).filter(t => t !== tag).join(' ') }));
-  }
-
-  // ── CRUD ──────────────────────────────────────────────────────────────────
-  askDelete(idx: number): void  { this.confirmIdx.set(idx); }
-  cancelDelete(): void          { this.confirmIdx.set(null); }
-  confirmDelete(): void {
-    const idx = this.confirmIdx(); if (idx === null) return;
-    const id  = this.events()[idx]?.id;
-    if (id) { this.expandedIds.update(s => { const n = new Set(s); n.delete(id); return n; }); this.dmNotesOpen.update(s => { const n = new Set(s); n.delete(id); return n; }); }
-    this.events.update(list => list.filter((_, i) => i !== idx)); this.confirmIdx.set(null);
+    this.ownEvents.update(list => [{
+      id, title: '', inGameDate: '', realDate: new Date().toISOString().split('T')[0],
+      type: 'other', summary: '', dmNotes: '', imageBase64: null, location: '', tags: '',
+    } as StoryEvent, ...list]);
+    this.newEventId.set(id);
   }
 
   save(): void {
     const username = this.auth.currentUser()?.username;
     if (!username) { this.snack.open('Nejsi přihlášen.', 'Zavřít', { verticalPosition: 'top', duration: 3000 }); return; }
-    this.store.saveDmStoryTimeline({ username, events: this.events(), sharedWith: this.sharedWith() });
+    this.store.saveDmStoryTimeline({ username, events: this.ownEvents(), sharedWith: this.sharedWith() });
   }
 
   // ── Share dialog ──────────────────────────────────────────────────────────
@@ -856,16 +353,13 @@ export class DmStoryTimelineComponent {
   saveSharing(): void {
     const username = this.auth.currentUser()?.username;
     if (!username) return;
-
     const oldList = this.sharedWith();
     const newList = this.pendingSharedWith();
     const toAdd    = newList.filter(u => !oldList.includes(u));
     const toRemove = oldList.filter(u => !newList.includes(u));
-
     this.sharedWith.set(newList);
     this.shareDialogOpen.set(false);
     this.save();
-
     const ops = [
       ...toAdd.map(u => this.api.setTimelineInvitation({ viewerUsername: u, ownerUsername: username })),
       ...toRemove.map(u => this.api.removeTimelineInvitation(u)),
@@ -873,33 +367,13 @@ export class DmStoryTimelineComponent {
     if (ops.length) forkJoin(ops).subscribe();
   }
 
-  // ── Image ─────────────────────────────────────────────────────────────────
-  selectImage(idx: number): void { this.pendingFileIdx.set(idx); this.globalFile()?.nativeElement.click(); }
-  removeImage(idx: number): void { this.events.update(list => list.map((e, i) => i !== idx ? e : { ...e, imageBase64: null })); }
-  onDragOver(e: DragEvent, idx: number): void { e.preventDefault(); e.stopPropagation(); if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'; this.dragOver.set(idx); }
-  onDrop(e: DragEvent, idx: number): void     { e.preventDefault(); e.stopPropagation(); this.dragOver.set(null); const f = e.dataTransfer?.files?.[0]; if (f) this.processFile(f, idx); }
-  onImageSelected(e: Event): void {
-    const idx = this.pendingFileIdx(); if (idx === null) return;
-    const input = e.target as HTMLInputElement; const file = input.files?.[0]; if (!file) return;
-    this.processFile(file, idx); input.value = ''; this.pendingFileIdx.set(null);
-  }
-  private processFile(file: File, idx: number): void {
-    if (!file.type.startsWith('image/')) { this.snack.open('Soubor není obrázek.', 'Zavřít', { verticalPosition: 'top', duration: 3000 }); return; }
-    if (file.size > 200 * 1024) { this.snack.open(`Obrázek příliš velký (${(file.size / 1024).toFixed(0)} KB). Max 200 KB.`, 'Zavřít', { verticalPosition: 'top', duration: 5000 }); return; }
-    const reader = new FileReader();
-    reader.onload = () => { const b64 = (reader.result as string).split(',')[1]; this.events.update(l => { const c = l.map(e => ({ ...e })); c[idx] = { ...c[idx], imageBase64: b64 }; return c; }); };
-    reader.readAsDataURL(file);
-  }
-  openPreview(e: MouseEvent, ev: StoryEvent): void { e.stopPropagation(); this.previewEvent.set(ev); }
-  closePreview(): void                              { this.previewEvent.set(null); }
+  onEscape(): void { if (this.shareDialogOpen()) this.shareDialogOpen.set(false); }
 
-  onEscape(): void {
-    if (this.previewEvent()) { this.closePreview(); return; }
-    if (this.confirmIdx() !== null) this.cancelDelete();
+  typeLabel(t: string): string {
+    const labels: Record<string, string> = {
+      world: 'Světová událost', campaign: 'Událost kampaně',
+      character: 'Událost postav', other: 'Jiné',
+    };
+    return labels[t] ?? t;
   }
-
-  // ── Helpers ───────────────────────────────────────────────────────────────
-  typeMeta(t: string) { return TYPE_META[t as StoryEventType] ?? TYPE_META['other']; }
-  parseTags(tags: string): string[]      { return tags.split(/[,\s]+/).map(t => t.trim()).filter(Boolean); }
 }
-

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -414,7 +414,7 @@ const ACL = '110,190,160'; // lighter teal
                 <!-- Summary -->
                 <div>
                   <div class="rt-label">Shrnutí události</div>
-                  <div class="rt-wrap">
+                  <div class="rt-wrap" style="margin-top: 5px;">
                     <rich-textarea [(ngModel)]="events()[item.idx].summary" style="position:absolute;top:0;left:0;width:100%;height:100%;"></rich-textarea>
                   </div>
                 </div>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -16,7 +16,9 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { SpinnerOverlayComponent, RichTextareaComponent } from '@dn-d-servant/ui';
 import { AuthService } from '@dn-d-servant/util';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { forkJoin } from 'rxjs';
 import { DmPageStore } from '../../dm-page.store';
+import { DmPageApiService } from '../../dm-page-api.service';
 import { StoryEvent, StoryEventType } from '../../dm-page-models';
 
 // ── Fuzzy-search helpers ──────────────────────────────────────────────────────
@@ -307,6 +309,53 @@ const ACL = '110,190,160'; // lighter teal
     .preview-title { font-family: sans-serif; font-size: 14px; color: #ddd5c5; text-align: center; }
     .preview-frame { border: 1px solid rgba(155,140,115,.28); border-radius: 4px; overflow: hidden; img { max-width: 85vw; max-height: 80vh; display: block; } }
     .preview-hint { font-size: 10px; color: rgba(155,140,115,.28); letter-spacing: .06em; }
+
+    /* ── Read-only banner ───────────────────────── */
+    .readonly-banner {
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+      margin-bottom: 16px; padding: 10px 16px;
+      background: rgba(100,140,210,.08);
+      border: 1px solid rgba(100,140,210,.25);
+      border-radius: 4px;
+      font-family: sans-serif; font-size: 12px; color: rgba(160,190,240,.8);
+      mat-icon { font-size: 16px; width: 16px; height: 16px; flex-shrink: 0; }
+    }
+    .readonly-banner__owner {
+      color: #a8c4f0; font-weight: 600;
+    }
+
+    /* ── Share dialog ───────────────────────────── */
+    .share-backdrop { position: fixed; inset: 0; z-index: 10000; background: rgba(0,0,0,.75); display: flex; align-items: center; justify-content: center; animation: fadeIn .14s ease; }
+    .share-dialog {
+      background: linear-gradient(160deg, rgba(14,10,4,.99) 0%, rgba(8,6,2,1) 100%);
+      border: 1px solid rgba(200,160,60,.35); border-top: 2px solid rgba(200,160,60,.7);
+      box-shadow: 0 12px 50px rgba(0,0,0,.9); border-radius: 3px;
+      padding: 26px 30px 22px; min-width: 340px; max-width: 460px; width: 90vw;
+      animation: scaleIn .14s ease;
+    }
+    .share-dialog__title { font-family: sans-serif; font-size: 13px; letter-spacing: .1em; text-transform: uppercase; color: #e8c96a; margin: 0 0 6px; }
+    .share-dialog__desc { font-size: 11px; color: rgba(255,255,255,.35); font-family: sans-serif; margin: 0 0 18px; font-style: italic; }
+    .share-dialog__section-label { font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: rgba(200,160,60,.4); margin-bottom: 8px; }
+    .share-dialog__input-row { display: flex; gap: 8px; margin-bottom: 16px; }
+    .share-dialog__input {
+      flex: 1; background: rgba(200,160,60,.06); border: 1px solid rgba(200,160,60,.22); border-radius: 4px;
+      color: rgba(220,210,190,.85); font-family: sans-serif; font-size: 13px; padding: 7px 12px; outline: none;
+      &:focus { border-color: rgba(200,160,60,.5); background: rgba(200,160,60,.1); }
+      &::placeholder { color: rgba(200,160,60,.25); }
+    }
+    .share-dialog__list { display: flex; flex-direction: column; gap: 5px; min-height: 40px; margin-bottom: 20px; }
+    .share-dialog__empty { font-size: 11px; color: rgba(255,255,255,.2); font-style: italic; font-family: sans-serif; padding: 6px 0; }
+    .share-dialog__player {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 6px 10px; background: rgba(200,160,60,.06); border: 1px solid rgba(200,160,60,.15); border-radius: 4px;
+    }
+    .share-dialog__player-name { font-family: sans-serif; font-size: 12px; color: rgba(220,200,150,.85); }
+    .share-dialog__remove {
+      background: none; border: none; cursor: pointer; color: rgba(200,80,70,.5); font-size: 16px; line-height: 1;
+      padding: 2px 4px; border-radius: 2px; transition: color .12s, background .12s;
+      &:hover { color: rgba(220,80,70,.9); background: rgba(200,50,40,.12); }
+    }
+    .share-dialog__actions { display: flex; gap: 8px; justify-content: flex-end; padding-top: 4px; border-top: 1px solid rgba(200,160,60,.12); margin-top: 4px; }
   `,
   template: `
     <spinner-overlay [diameter]="60" [showSpinner]="store.loading()">
@@ -329,9 +378,22 @@ const ACL = '110,190,160'; // lighter teal
         <button class="pt-filter-btn" (click)="toggleAllExpanded()" [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozbalit vše'">
           <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
         </button>
-        <button class="pt-filter-btn" (click)="addEvent()"><mat-icon>add</mat-icon> Přidat událost</button>
-        <button class="btn btn-save" (click)="save()"><mat-icon>save</mat-icon> Uložit</button>
+        @if (!isReadOnly()) {
+          <button class="pt-filter-btn" (click)="addEvent()"><mat-icon>add</mat-icon> Přidat událost</button>
+          <button class="pt-filter-btn" (click)="openShareDialog()" matTooltip="Sdílet s hráči">
+            <mat-icon>share</mat-icon> Sdílet
+          </button>
+          <button class="btn btn-save" (click)="save()"><mat-icon>save</mat-icon> Uložit</button>
+        }
       </div>
+
+      <!-- Read-only banner -->
+      @if (isReadOnly()) {
+        <div class="readonly-banner">
+          <mat-icon>visibility</mat-icon>
+          Zobrazuješ příběhové události sdílené hráčem <span class="readonly-banner__owner">{{ ownerUsername() }}</span>. Obsah je pouze pro čtení.
+        </div>
+      }
 
       <!-- Tag filter row -->
       @if (allTags().length > 0) {
@@ -368,7 +430,8 @@ const ACL = '110,190,160'; // lighter teal
             <!-- Card header -->
             <div class="card-header" (click)="toggleExpand(item.event.id)">
               <span class="type-badge" [style.color]="typeMeta(item.event.type).color" [style.background]="typeMeta(item.event.type).bg"
-                (click)="$event.stopPropagation(); cycleType(item.idx)" matTooltip="Kliknutím změnit typ">{{ typeMeta(item.event.type).label }}</span>
+                (click)="$event.stopPropagation(); !isReadOnly() && cycleType(item.idx)"
+                [matTooltip]="isReadOnly() ? '' : 'Kliknutím změnit typ'">{{ typeMeta(item.event.type).label }}</span>
 
               <div class="card-title-wrap">
                 <div class="card-title" [class.card-title--placeholder]="!item.event.title">
@@ -383,11 +446,13 @@ const ACL = '110,190,160'; // lighter teal
                 <span class="card-date">{{ item.event.realDate }}</span>
               }
 
-              <div class="card-actions" (click)="$event.stopPropagation()">
-                <button class="card-action-btn card-action-btn--danger" (click)="askDelete(item.idx)" matTooltip="Smazat událost">
-                  <mat-icon>delete_outline</mat-icon>
-                </button>
-              </div>
+              @if (!isReadOnly()) {
+                <div class="card-actions" (click)="$event.stopPropagation()">
+                  <button class="card-action-btn card-action-btn--danger" (click)="askDelete(item.idx)" matTooltip="Smazat událost">
+                    <mat-icon>delete_outline</mat-icon>
+                  </button>
+                </div>
+              }
               <div class="expand-chevron" [class.expand-chevron--open]="expandedIds().has(item.event.id)">
                 <mat-icon>expand_more</mat-icon>
               </div>
@@ -410,7 +475,7 @@ const ACL = '110,190,160'; // lighter teal
                 <div class="field-row">
                   <div class="field-group" style="flex:1;min-width:200px">
                     <div class="field-label">Název události</div>
-                    <input class="field-input" [(ngModel)]="events()[item.idx].title" placeholder="Název…" />
+                    <input class="field-input" [(ngModel)]="events()[item.idx].title" placeholder="Název…" [disabled]="isReadOnly()" />
                   </div>
                 </div>
 
@@ -418,10 +483,18 @@ const ACL = '110,190,160'; // lighter teal
                 <div class="field-row">
                   <div class="field-group">
                     <div class="field-label">Místo</div>
-                    <input class="field-input" [(ngModel)]="events()[item.idx].location" placeholder="Město, dungeon, les…" />
+                    <input class="field-input" [(ngModel)]="events()[item.idx].location" placeholder="Město, dungeon, les…" [disabled]="isReadOnly()" />
                   </div>
                   <div class="field-group" style="flex:2">
                     <div class="field-label">Štítky</div>
+                    @if (isReadOnly()) {
+                      <div class="tag-input-wrap" style="pointer-events:none;opacity:.7;">
+                        @for (tag of parseTags(events()[item.idx].tags); track tag) {
+                          <span class="tag-chip tag-chip--removable">{{ tag }}</span>
+                        }
+                      </div>
+                    }
+                    @if (!isReadOnly()) {
                     <div class="tag-field-wrap">
                       <div class="tag-input-wrap" (click)="focusTagInput(item.event.id)">
                         @for (tag of parseTags(events()[item.idx].tags); track tag) {
@@ -458,6 +531,7 @@ const ACL = '110,190,160'; // lighter teal
                         </div>
                       }
                     </div>
+                    }
                   </div>
                 </div>
 
@@ -475,6 +549,49 @@ const ACL = '110,190,160'; // lighter teal
         }
       </div>
     </spinner-overlay>
+
+    <!-- Share dialog -->
+    @if (shareDialogOpen()) {
+      <div class="share-backdrop" (click)="shareDialogOpen.set(false)">
+        <div class="share-dialog" (click)="$event.stopPropagation()">
+          <div class="share-dialog__title">Sdílet příběhové události</div>
+          <div class="share-dialog__desc">Pozvaní hráči uvidí události v režimu pouze pro čtení pod svým přihlášením.</div>
+
+          <div class="share-dialog__section-label">Přidat hráče</div>
+          <div class="share-dialog__input-row">
+            <input
+              class="share-dialog__input"
+              [(ngModel)]="shareInput"
+              placeholder="Uživatelské jméno hráče…"
+              (keydown.enter)="addSharePlayer()"
+            />
+            <button class="pt-filter-btn" type="button" (click)="addSharePlayer()">
+              <mat-icon>add</mat-icon> Přidat
+            </button>
+          </div>
+
+          <div class="share-dialog__section-label">Sdíleno s ({{ pendingSharedWith().length }})</div>
+          <div class="share-dialog__list">
+            @if (pendingSharedWith().length === 0) {
+              <span class="share-dialog__empty">Zatím nesdíleno s nikým.</span>
+            }
+            @for (player of pendingSharedWith(); track player) {
+              <div class="share-dialog__player">
+                <span class="share-dialog__player-name">{{ player }}</span>
+                <button class="share-dialog__remove" type="button" (click)="removeSharePlayer(player)" title="Odebrat">✕</button>
+              </div>
+            }
+          </div>
+
+          <div class="share-dialog__actions">
+            <button class="pt-filter-btn" type="button" (click)="shareDialogOpen.set(false)">Zrušit</button>
+            <button class="btn btn-save" type="button" (click)="saveSharing()">
+              <mat-icon>save</mat-icon> Uložit sdílení
+            </button>
+          </div>
+        </div>
+      </div>
+    }
 
     <input #globalFile type="file" accept="image/*" class="img-file-input" (change)="onImageSelected($event)" />
 
@@ -511,6 +628,7 @@ const ACL = '110,190,160'; // lighter teal
 export class DmStoryTimelineComponent {
   readonly store   = inject(DmPageStore);
   private readonly auth  = inject(AuthService);
+  private readonly api   = inject(DmPageApiService);
   private readonly snack = inject(MatSnackBar);
 
   events      = signal<StoryEvent[]>([]);
@@ -522,6 +640,16 @@ export class DmStoryTimelineComponent {
   confirmIdx  = signal<number | null>(null);
   dragOver    = signal<number | null>(null);
   previewEvent = signal<StoryEvent | null>(null);
+
+  // ── Sharing ────────────────────────────────────────────────────────────────
+  /** Username of the owner whose data we're viewing; null = viewing own data */
+  ownerUsername = signal<string | null>(null);
+  readonly isReadOnly = computed(() => this.ownerUsername() !== null);
+  /** sharedWith list from the loaded timeline */
+  sharedWith = signal<string[]>([]);
+  shareDialogOpen = signal(false);
+  shareInput = '';
+  pendingSharedWith = signal<string[]>([]);
 
   /** Per-event current tag text being typed */
   private tagInputMap = signal<Record<string, string>>({});
@@ -563,13 +691,32 @@ export class DmStoryTimelineComponent {
   });
 
   constructor() {
+    // When store data arrives, populate events + sharedWith
     effect(() => {
       const data = this.store.dmStoryTimeline();
-      untracked(() => { if (data?.events) this.events.set(data.events.map(e => ({ ...e }))); });
+      untracked(() => {
+        if (data?.events) {
+          this.events.set(data.events.map(e => ({ ...e })));
+          this.sharedWith.set(data.sharedWith ?? []);
+        }
+      });
     });
+
+    // On auth, check invitation then load appropriate data
     effect(() => {
       const username = this.auth.currentUser()?.username;
-      untracked(() => { if (username) this.store.loadDmStoryTimeline(username); });
+      untracked(() => {
+        if (!username) return;
+        this.api.getTimelineInvitation(username).subscribe(inv => {
+          if (inv?.ownerUsername && inv.ownerUsername !== username) {
+            this.ownerUsername.set(inv.ownerUsername);
+            this.store.loadDmStoryTimeline(inv.ownerUsername);
+          } else {
+            this.ownerUsername.set(null);
+            this.store.loadDmStoryTimeline(username);
+          }
+        });
+      });
     });
   }
 
@@ -682,7 +829,48 @@ export class DmStoryTimelineComponent {
   save(): void {
     const username = this.auth.currentUser()?.username;
     if (!username) { this.snack.open('Nejsi přihlášen.', 'Zavřít', { verticalPosition: 'top', duration: 3000 }); return; }
-    this.store.saveDmStoryTimeline({ username, events: this.events() });
+    this.store.saveDmStoryTimeline({ username, events: this.events(), sharedWith: this.sharedWith() });
+  }
+
+  // ── Share dialog ──────────────────────────────────────────────────────────
+  openShareDialog(): void {
+    this.pendingSharedWith.set([...this.sharedWith()]);
+    this.shareInput = '';
+    this.shareDialogOpen.set(true);
+  }
+
+  addSharePlayer(): void {
+    const name = this.shareInput.trim().toLowerCase();
+    if (!name) return;
+    const current = this.auth.currentUser()?.username?.toLowerCase();
+    if (name === current) { this.snack.open('Nemůžeš pozvat sám sebe.', '✕', { verticalPosition: 'top', duration: 2500 }); return; }
+    if (this.pendingSharedWith().includes(name)) return;
+    this.pendingSharedWith.update(list => [...list, name]);
+    this.shareInput = '';
+  }
+
+  removeSharePlayer(player: string): void {
+    this.pendingSharedWith.update(list => list.filter(p => p !== player));
+  }
+
+  saveSharing(): void {
+    const username = this.auth.currentUser()?.username;
+    if (!username) return;
+
+    const oldList = this.sharedWith();
+    const newList = this.pendingSharedWith();
+    const toAdd    = newList.filter(u => !oldList.includes(u));
+    const toRemove = oldList.filter(u => !newList.includes(u));
+
+    this.sharedWith.set(newList);
+    this.shareDialogOpen.set(false);
+    this.save();
+
+    const ops = [
+      ...toAdd.map(u => this.api.setTimelineInvitation({ viewerUsername: u, ownerUsername: username })),
+      ...toRemove.map(u => this.api.removeTimelineInvitation(u)),
+    ];
+    if (ops.length) forkJoin(ops).subscribe();
   }
 
   // ── Image ─────────────────────────────────────────────────────────────────

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -1,5 +1,6 @@
 import {
-  ChangeDetectionStrategy, Component, computed, effect, inject, signal, untracked,
+  ChangeDetectionStrategy, Component, computed, effect, inject, QueryList,
+  signal, untracked, ViewChildren,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatIcon } from '@angular/material/icon';
@@ -129,6 +130,12 @@ import { StoryEventsListComponent } from './story-events-list.component';
           <option value="oldest">Nejstarší první</option>
         </select>
         <span class="filter-bar-spacer"></span>
+        @if (activeEvents().length > 0) {
+          <button class="pt-filter-btn" type="button" (click)="activeList?.toggleAllExpanded()"
+            [matTooltip]="activeList?.allExpanded() ? 'Sbalit vše' : 'Rozbalit vše'">
+            <mat-icon>{{ activeList?.allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+          </button>
+        }
         @if (activeTab() === 'own') {
           <button class="pt-filter-btn" (click)="addEvent()"><mat-icon>add</mat-icon> Přidat událost</button>
           <button class="pt-filter-btn" (click)="openShareDialog()" matTooltip="Sdílet moje události s hráči">
@@ -235,6 +242,9 @@ export class DmStoryTimelineComponent {
   private readonly auth  = inject(AuthService);
   private readonly api   = inject(DmPageApiService);
   private readonly snack = inject(MatSnackBar);
+
+  @ViewChildren(StoryEventsListComponent) private lists!: QueryList<StoryEventsListComponent>;
+  get activeList(): StoryEventsListComponent | undefined { return this.lists?.first; }
 
   // ── Events state ──────────────────────────────────────────────────────────
   ownEvents    = signal<StoryEvent[]>([]);

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.component.ts
@@ -280,21 +280,11 @@ const ACL = '110,190,160'; // lighter teal
   template: `
     <spinner-overlay [diameter]="60" [showSpinner]="store.loading()">
 
-      <!-- Header -->
-      <div class="header">
-        <div>
-          <div class="header-title">
-            <mat-icon>auto_stories</mat-icon>
-            Příběhové události
-          </div>
-          <div class="header-subtitle">Kronika klíčových momentů vaší kampaně</div>
-        </div>
-        <div class="header-actions">
-          <button class="btn btn-icon" (click)="expandAll()" matTooltip="Rozbalit vše"><mat-icon>unfold_more</mat-icon></button>
-          <button class="btn btn-icon" (click)="collapseAll()" matTooltip="Sbalit vše"><mat-icon>unfold_less</mat-icon></button>
-          <button class="btn" (click)="addEvent()"><mat-icon>add</mat-icon> Přidat událost</button>
-          <button class="btn btn-save" (click)="save()"><mat-icon>save</mat-icon> Uložit</button>
-        </div>
+      <div class="header-actions">
+        <button class="btn btn-icon" (click)="expandAll()" matTooltip="Rozbalit vše"><mat-icon>unfold_more</mat-icon></button>
+        <button class="btn btn-icon" (click)="collapseAll()" matTooltip="Sbalit vše"><mat-icon>unfold_less</mat-icon></button>
+        <button class="btn" (click)="addEvent()"><mat-icon>add</mat-icon> Přidat událost</button>
+        <button class="btn btn-save" (click)="save()"><mat-icon>save</mat-icon> Uložit</button>
       </div>
 
       <!-- Type filter + sort -->

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.types.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/dm-story-timeline.types.ts
@@ -1,0 +1,55 @@
+import { StoryEventType } from '../../dm-page-models';
+
+export const TYPE_META: Record<StoryEventType, { label: string; icon: string; color: string; bg: string }> = {
+  world:     { label: 'Světová událost',  icon: 'public',       color: 'rgba(100,140,210,.9)', bg: 'rgba(70,110,190,.10)' },
+  campaign:  { label: 'Událost kampaně',  icon: 'auto_stories', color: 'rgba(210,175,55,.9)',  bg: 'rgba(190,155,40,.10)' },
+  character: { label: 'Událost postav',   icon: 'person',       color: 'rgba(60,185,150,.9)',  bg: 'rgba(40,160,120,.10)' },
+  other:     { label: 'Jiné',             icon: 'bookmark',     color: 'rgba(130,130,130,.8)', bg: 'rgba(100,100,100,.08)'},
+};
+
+export const TYPE_ORDER: StoryEventType[] = ['world', 'campaign', 'character', 'other'];
+
+export type FilterType = 'all' | StoryEventType;
+export type SortOrder  = 'newest' | 'oldest';
+
+export function parseTags(tags: string): string[] {
+  return tags.split(/[,\s]+/).map(t => t.trim()).filter(Boolean);
+}
+
+export function posNorm(s: string): string {
+  return s.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase();
+}
+
+export function fuzzySubsequence(query: string, text: string): number[] | null {
+  const indices: number[] = [];
+  let ti = 0;
+  for (let qi = 0; qi < query.length; qi++) {
+    const ch = query[qi];
+    while (ti < text.length && text[ti] !== ch) ti++;
+    if (ti >= text.length) return null;
+    indices.push(ti); ti++;
+  }
+  return indices;
+}
+
+function escHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function buildHighlightHtml(original: string, indices: number[]): string {
+  const matchSet = new Set(indices);
+  const parts: string[] = [];
+  let inSpan = false;
+  for (let i = 0; i < original.length; i++) {
+    const ch = escHtml(original[i]);
+    if (matchSet.has(i)) {
+      if (!inSpan) { parts.push('<span class="hl">'); inSpan = true; }
+      parts.push(ch);
+    } else {
+      if (inSpan) { parts.push('</span>'); inSpan = false; }
+      parts.push(ch);
+    }
+  }
+  if (inSpan) parts.push('</span>');
+  return parts.join('');
+}

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
@@ -326,6 +326,8 @@ export class StoryEventsListComponent {
   sortOrder  = input<SortOrder>('newest');
   /** When set to an event id, that event is auto-expanded */
   autoExpandId = input<string | null>(null);
+  /** localStorage key for persisting expand state */
+  storageKey = input<string>();
 
   /** Flat read-only view of the signal's current array */
   readonly events = computed(() => this.eventsRef()());
@@ -364,7 +366,32 @@ export class StoryEventsListComponent {
     this.events().length > 0 && this.events().every(e => this.expandedIds().has(e.id))
   );
 
+  private _storageLoaded = false;
+
   constructor() {
+    // Load expandedIds from localStorage when storageKey becomes available
+    effect(() => {
+      const key = this.storageKey();
+      untracked(() => {
+        if (!key || this._storageLoaded) return;
+        this._storageLoaded = true;
+        try {
+          const raw = localStorage.getItem(key);
+          if (raw) this.expandedIds.set(new Set(JSON.parse(raw) as string[]));
+        } catch { /* ignore */ }
+      });
+    });
+
+    // Persist expandedIds to localStorage on every change
+    effect(() => {
+      const ids = this.expandedIds();
+      const key = this.storageKey();
+      if (key && this._storageLoaded) {
+        localStorage.setItem(key, JSON.stringify([...ids]));
+      }
+    });
+
+    // Auto-expand newly added event
     effect(() => {
       const id = this.autoExpandId();
       if (id) untracked(() => this.expandedIds.update(s => { const n = new Set(s); n.add(id); return n; }));

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
@@ -1,0 +1,485 @@
+import {
+  ChangeDetectionStrategy, Component, computed, effect, input, signal, untracked, WritableSignal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatIcon } from '@angular/material/icon';
+import { MatIconButton } from '@angular/material/button';
+import { MatTooltip } from '@angular/material/tooltip';
+import { RichTextareaComponent } from '@dn-d-servant/ui';
+import { StoryEvent } from '../../dm-page-models';
+import {
+  TYPE_META, TYPE_ORDER, FilterType, SortOrder,
+  parseTags, posNorm, fuzzySubsequence, buildHighlightHtml,
+} from './dm-story-timeline.types';
+
+@Component({
+  selector: 'story-events-list',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, MatIcon, MatIconButton, MatTooltip, RichTextareaComponent],
+  styles: `
+    /* ── pt-filter-btn icon support ─────────────── */
+    .pt-filter-btn { display: inline-flex; align-items: center; gap: 5px;
+      mat-icon, .mat-icon { font-size: 14px; width: 14px; height: 14px; } }
+
+    /* ── List toolbar ────────────────────────────── */
+    .sl-toolbar { display: flex; align-items: center; justify-content: flex-end; margin-bottom: 12px; min-height: 32px; }
+
+    /* ── Timeline container ──────────────────────── */
+    .timeline { position: relative; padding-left: 48px; }
+    .timeline-line {
+      position: absolute; left: 16px; top: 0; bottom: 0; width: 2px;
+      background: linear-gradient(180deg, transparent, rgba(155,140,115,.28) 5%, rgba(155,140,115,.28) 95%, transparent);
+    }
+
+    /* ── Timeline node ─────────────────────────── */
+    .tl-node {
+      position: absolute; left: -40px; top: 18px;
+      width: 28px; height: 28px; border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      border: 2px solid; background: rgba(14,12,8,.96);
+      mat-icon { font-size: 14px; width: 14px; height: 14px; }
+    }
+
+    /* ── Event card ──────────────────────────────── */
+    .event-card {
+      position: relative; border-radius: 3px; margin-bottom: 20px;
+      background: rgba(22,20,18,.97); border: 1px solid rgba(200,160,60,.15);
+      box-shadow: 0 4px 20px rgba(0,0,0,.55); transition: border-color .2s, box-shadow .2s; overflow: hidden;
+      &:hover { border-color: rgba(200,160,60,.28); box-shadow: 0 6px 28px rgba(0,0,0,.65); }
+    }
+
+    /* ── Card header ────────────────────────────── */
+    .card-header { display: flex; align-items: center; gap: 8px; padding: 10px 12px 7px; flex-wrap: wrap; cursor: pointer; user-select: none; }
+    .type-badge {
+      font-family: sans-serif; font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
+      border-radius: 6px; padding: 4px 12px; cursor: pointer; border: 1px solid currentColor;
+      transition: filter .15s; white-space: nowrap; flex-shrink: 0;
+      &:hover { filter: brightness(1.18); }
+    }
+    .card-title-wrap { flex: 1; min-width: 0; overflow: hidden; }
+    .card-title {
+      font-family: sans-serif; font-size: 16px; font-weight: 500; color: #ddd5c5;
+      display: flex; align-items: center; gap: 10px; overflow: hidden;
+      &--placeholder { color: rgba(200,185,160,.2); font-style: italic; }
+    }
+    .card-title-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex-shrink: 1; min-width: 0; }
+    .card-date { font-family: sans-serif; font-size: 9px; color: rgba(175,160,135,.42); letter-spacing: .04em; white-space: nowrap; flex-shrink: 0; }
+    .card-location { font-family: sans-serif; font-size: 10px; color: rgba(175,160,135,.35); letter-spacing: .03em;
+      display: flex; align-items: center; gap: 3px; white-space: nowrap; flex-shrink: 0;
+      mat-icon { font-size: 11px; width: 11px; height: 11px; }
+    }
+    .card-actions { display: flex; gap: 2px; align-items: center; flex-shrink: 0; }
+    .card-action-btn {
+      background: none; border: none; cursor: pointer; color: rgba(155,140,115,.38); padding: 4px; border-radius: 3px;
+      transition: color .15s, background .15s; display: flex; align-items: center;
+      mat-icon { font-size: 16px; width: 16px; height: 16px; }
+      &:hover { color: rgba(185,170,140,.8); background: rgba(140,125,100,.1); }
+      &--danger:hover { color: rgba(220,80,70,.8); background: rgba(200,60,50,.1); }
+    }
+    .expand-chevron { transition: transform .2s; mat-icon { font-size: 16px; width: 16px; height: 16px; color: rgba(155,140,115,.38); } }
+    .expand-chevron--open { transform: rotate(180deg); }
+
+    /* ── Tag chips (collapsed view) ─────────────── */
+    .tag-list { display: flex; gap: 5px; flex-wrap: wrap; padding: 0 12px 8px; }
+    .tag-chip {
+      font-family: sans-serif; font-size: 11px; padding: 3px 9px; border-radius: 10px;
+      background: rgba(140,125,100,.1); border: 1px solid rgba(155,140,115,.2); color: rgba(185,170,140,.7);
+      letter-spacing: .03em; display: inline-flex; align-items: center; gap: 4px;
+    }
+
+    /* ── Expanded body ───────────────────────────── */
+    .card-body { padding: 0 12px 14px; display: flex; flex-direction: column; gap: 10px; }
+    .field-row { display: flex; gap: 10px; flex-wrap: wrap; }
+    .field-group { display: flex; flex-direction: column; gap: 4px; flex: 1; min-width: 180px; }
+    .field-label { font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: rgba(155,140,115,.38); }
+    .field-input {
+      background: rgba(140,125,100,.06); border: 1px solid rgba(155,140,115,.16); border-radius: 3px;
+      color: rgba(220,210,190,.85); font-family: sans-serif; font-size: 13px; padding: 6px 10px; width: 100%; box-sizing: border-box;
+      &:focus { outline: none; border-color: rgba(155,140,115,.38); background: rgba(140,125,100,.1); }
+      &::placeholder { color: rgba(155,140,115,.22); }
+      &:disabled { opacity: .6; cursor: not-allowed; }
+    }
+    .rt-label { font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: rgba(155,140,115,.38); margin-bottom: 3px; }
+    .rt-wrap { position: relative; height: 160px; background: rgba(140,125,100,.05); border: 1px solid rgba(155,140,115,.13); border-radius: 3px; overflow: visible; margin-top: 44px; }
+
+    /* ── Tag input (edit mode) ───────────────────── */
+    .tag-field-wrap { position: relative; }
+    .tag-input-wrap {
+      display: flex; flex-wrap: wrap; gap: 4px; align-items: center;
+      background: rgba(140,125,100,.06); border: 1px solid rgba(155,140,115,.16); border-radius: 3px;
+      padding: 5px 8px; min-height: 36px; cursor: text;
+      &:focus-within { border-color: rgba(155,140,115,.38); background: rgba(140,125,100,.1); }
+    }
+    .tag-chip--removable { background: rgba(140,125,100,.14); border-color: rgba(155,140,115,.3); color: #d8cdb8; padding-right: 4px; }
+    .tag-chip-remove {
+      background: none; border: none; cursor: pointer; color: rgba(185,170,140,.55); font-size: 14px; line-height: 1;
+      padding: 2px 4px; display: flex; align-items: center; transition: color .12s, background .12s; border-radius: 3px;
+      &:hover { color: rgba(220,80,70,.9); background: rgba(200,50,40,.15); }
+    }
+    .tag-text-input {
+      background: transparent; border: none; outline: none; color: rgba(220,210,190,.85);
+      font-family: sans-serif; font-size: 12px; min-width: 100px; flex: 1;
+      &::placeholder { color: rgba(155,140,115,.22); }
+    }
+    .tag-suggestions {
+      position: absolute; top: calc(100% + 2px); left: 0; right: 0; z-index: 200;
+      background: rgba(18,14,8,.98); border: 1px solid rgba(155,140,115,.35); border-radius: 4px;
+      max-height: 180px; overflow-y: auto; box-shadow: 0 6px 20px rgba(0,0,0,.7);
+    }
+    .tag-suggestion-item {
+      display: block; width: 100%; text-align: left; padding: 7px 12px;
+      background: none; border: none; border-bottom: 1px solid rgba(155,140,115,.08);
+      color: rgba(220,210,190,.75); font-size: 11px; font-family: sans-serif; cursor: pointer;
+      transition: background .1s, color .1s;
+      &:last-child { border-bottom: none; }
+      &:hover, &--active { background: rgba(155,140,115,.12); color: #d8cdb8; }
+    }
+    ::ng-deep .tag-suggestions .hl { color: rgba(210,175,55,.95); font-weight: 700; }
+
+    /* ── Empty state ─────────────────────────────── */
+    .empty-state { text-align: center; padding: 70px 20px; color: rgba(255,255,255,.1); font-size: 13px; letter-spacing: .1em;
+      mat-icon { font-size: 54px; width: 54px; height: 54px; display: block; margin: 0 auto 16px; color: rgba(155,140,115,.1); }
+    }
+
+    /* ── Confirm dialog ──────────────────────────── */
+    .confirm-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.72); display: flex; align-items: center; justify-content: center; z-index: 1100; }
+    .confirm-dialog { background: linear-gradient(160deg,rgba(22,18,12,.99),rgba(14,11,7,.99)); border: 1px solid rgba(200,80,60,.4); border-radius: 6px; padding: 28px 32px; max-width: 360px; width: 90vw; text-align: center; animation: scaleIn .14s ease; }
+    .confirm-icon { color: rgba(220,60,50,.7); mat-icon { font-size: 36px; width: 36px; height: 36px; } }
+    .confirm-title { font-size: 16px; letter-spacing: .1em; color: #f0b0b0; margin: 10px 0 6px; text-transform: uppercase; }
+    .confirm-msg { font-size: 12px; color: rgba(220,180,180,.6); font-family: sans-serif; }
+    .confirm-rule { height: 1px; background: linear-gradient(90deg,transparent,rgba(200,80,60,.3),transparent); margin: 16px 0; }
+    .confirm-actions { display: flex; gap: 10px; justify-content: center; }
+    .confirm-btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase; padding: 7px 20px; border-radius: 3px; cursor: pointer; border: 1px solid; }
+    .confirm-cancel { color: rgba(180,160,140,.7); border-color: rgba(180,160,140,.25); background: transparent; &:hover { background: rgba(180,160,140,.08); } }
+    .confirm-delete { color: rgba(220,80,70,.85); border-color: rgba(200,60,50,.4); background: rgba(200,50,40,.1); &:hover { background: rgba(200,50,40,.2); } }
+
+    /* ── Btn (save, etc.) ────────────────────────── */
+    .btn { font-family: sans-serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
+      border: 1px solid rgba(155,140,115,.35); border-radius: 3px; background: rgba(140,125,100,.08); color: rgba(175,160,135,.85);
+      padding: 6px 14px; cursor: pointer; display: flex; align-items: center; gap: 5px; transition: background .18s, border-color .18s, color .18s;
+      mat-icon { font-size: 15px; width: 15px; height: 15px; }
+      &:hover { background: rgba(140,125,100,.16); border-color: rgba(155,140,115,.6); color: #d8cdb8; }
+    }
+
+    @keyframes scaleIn { from { transform: scale(.92); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+  `,
+  template: `
+    <!-- Toolbar: expand/collapse all -->
+    <div class="sl-toolbar">
+      @if (events().length > 0) {
+        <button class="pt-filter-btn" type="button" (click)="toggleAllExpanded()"
+          [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozbalit vše'">
+          <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
+        </button>
+      }
+    </div>
+
+    <div class="timeline">
+      <div class="timeline-line"></div>
+
+      @if (filtered().length === 0) {
+        <div class="empty-state">
+          <mat-icon>auto_stories</mat-icon>
+          @if (events().length === 0) { Žádné události — přidej první kapitolu příběhu. }
+          @else { Žádné události neodpovídají filtru. }
+        </div>
+      }
+
+      @for (item of filtered(); track item.event.id) {
+        <div class="event-card">
+
+          <div class="tl-node"
+            [style.border-color]="typeMeta(item.event.type).color"
+            [style.color]="typeMeta(item.event.type).color">
+            <mat-icon>{{ typeMeta(item.event.type).icon }}</mat-icon>
+          </div>
+
+          <!-- Card header -->
+          <div class="card-header" (click)="toggleExpand(item.event.id)">
+            <span class="type-badge"
+              [style.color]="typeMeta(item.event.type).color"
+              [style.background]="typeMeta(item.event.type).bg"
+              (click)="$event.stopPropagation(); !isReadOnly() && cycleType(item.idx)"
+              [matTooltip]="isReadOnly() ? '' : 'Kliknutím změnit typ'">{{ typeMeta(item.event.type).label }}</span>
+
+            <div class="card-title-wrap">
+              <div class="card-title" [class.card-title--placeholder]="!item.event.title">
+                <span class="card-title-text">{{ item.event.title || 'Bez názvu…' }}</span>
+                @if (item.event.location) {
+                  <span class="card-location"><mat-icon>location_on</mat-icon>{{ item.event.location }}</span>
+                }
+              </div>
+            </div>
+
+            @if (item.event.realDate) {
+              <span class="card-date">{{ item.event.realDate }}</span>
+            }
+
+            @if (!isReadOnly()) {
+              <div class="card-actions" (click)="$event.stopPropagation()">
+                <button class="card-action-btn card-action-btn--danger" (click)="askDelete(item.idx)" matTooltip="Smazat událost">
+                  <mat-icon>delete_outline</mat-icon>
+                </button>
+              </div>
+            }
+
+            <div class="expand-chevron" [class.expand-chevron--open]="expandedIds().has(item.event.id)">
+              <mat-icon>expand_more</mat-icon>
+            </div>
+          </div>
+
+          <!-- Tags (collapsed) -->
+          @if (parseTags(item.event.tags).length > 0 && !expandedIds().has(item.event.id)) {
+            <div class="tag-list">
+              @for (tag of parseTags(item.event.tags); track tag) {
+                <span class="tag-chip">{{ tag }}</span>
+              }
+            </div>
+          }
+
+          <!-- Expanded body -->
+          @if (expandedIds().has(item.event.id)) {
+            <div class="card-body">
+
+              <div class="field-row">
+                <div class="field-group" style="flex:1;min-width:200px">
+                  <div class="field-label">Název události</div>
+                  <input class="field-input" [(ngModel)]="events()[item.idx].title" placeholder="Název…" [disabled]="isReadOnly()" />
+                </div>
+              </div>
+
+              <div class="field-row">
+                <div class="field-group">
+                  <div class="field-label">Místo</div>
+                  <input class="field-input" [(ngModel)]="events()[item.idx].location" placeholder="Město, dungeon, les…" [disabled]="isReadOnly()" />
+                </div>
+                <div class="field-group" style="flex:2">
+                  <div class="field-label">Štítky</div>
+                  @if (isReadOnly()) {
+                    <div class="tag-input-wrap" style="pointer-events:none;opacity:.7;">
+                      @for (tag of parseTags(events()[item.idx].tags); track tag) {
+                        <span class="tag-chip tag-chip--removable">{{ tag }}</span>
+                      }
+                    </div>
+                  }
+                  @if (!isReadOnly()) {
+                    <div class="tag-field-wrap">
+                      <div class="tag-input-wrap" (click)="focusTagInput(item.event.id)">
+                        @for (tag of parseTags(events()[item.idx].tags); track tag) {
+                          <span class="tag-chip tag-chip--removable">
+                            {{ tag }}
+                            <button class="tag-chip-remove" type="button" (click)="$event.stopPropagation(); removeTag(item.idx, tag)">×</button>
+                          </span>
+                        }
+                        <input
+                          class="tag-text-input"
+                          [id]="'tag-input-' + item.event.id"
+                          [ngModel]="getTagInput(item.event.id)"
+                          (ngModelChange)="setTagInput(item.event.id, $event)"
+                          (keydown.enter)="$event.preventDefault(); onTagEnter(item.idx, item.event.id)"
+                          (keydown.space)="$event.preventDefault(); addTagFromInput(item.idx)"
+                          (keydown.arrowdown)="$event.preventDefault(); navigateSuggestions(item.event.id, 1)"
+                          (keydown.arrowup)="$event.preventDefault(); navigateSuggestions(item.event.id, -1)"
+                          (keydown.escape)="setActiveSuggIdx(item.event.id, -1)"
+                          (blur)="onTagBlur(item.idx)"
+                          placeholder="{{ parseTags(events()[item.idx].tags).length ? '' : 'Přidat štítek…' }}"
+                        />
+                      </div>
+                      @if (getTagSuggestions(item.event.id).length > 0) {
+                        <div class="tag-suggestions">
+                          @for (sugg of getTagSuggestions(item.event.id); track sugg.tag; let si = $index) {
+                            <button class="tag-suggestion-item"
+                              [class.tag-suggestion-item--active]="getActiveSuggIdx(item.event.id) === si"
+                              type="button"
+                              (mousedown)="$event.preventDefault()"
+                              (click)="selectSuggestion(item.idx, sugg.tag)"
+                            ><span [innerHTML]="sugg.html"></span></button>
+                          }
+                        </div>
+                      }
+                    </div>
+                  }
+                </div>
+              </div>
+
+              <div>
+                <div class="rt-label">Shrnutí události</div>
+                <div class="rt-wrap">
+                  <rich-textarea [(ngModel)]="events()[item.idx].summary" style="position:absolute;top:0;left:0;width:100%;height:100%;"></rich-textarea>
+                </div>
+              </div>
+
+            </div>
+          }
+        </div>
+      }
+    </div>
+
+    @if (confirmIdx() !== null) {
+      <div class="confirm-backdrop" (click)="cancelDelete()">
+        <div class="confirm-dialog" (click)="$event.stopPropagation()">
+          <div class="confirm-icon"><mat-icon>delete_forever</mat-icon></div>
+          <div class="confirm-title">Smazat událost?</div>
+          <div class="confirm-msg">
+            Opravdu smazat
+            @if (events()[confirmIdx()!]?.title) { <strong>„{{ events()[confirmIdx()!].title }}"</strong> }
+            @else { <strong>tuto událost</strong> }?
+          </div>
+          <div class="confirm-rule"></div>
+          <div class="confirm-actions">
+            <button class="confirm-btn confirm-cancel" (click)="cancelDelete()">Zrušit</button>
+            <button class="confirm-btn confirm-delete" (click)="confirmDelete()">Smazat</button>
+          </div>
+        </div>
+      </div>
+    }
+  `,
+})
+export class StoryEventsListComponent {
+  /** Reference to parent's WritableSignal — child reads and mutates it directly */
+  eventsRef  = input.required<WritableSignal<StoryEvent[]>>();
+  isReadOnly = input(false);
+  filterType = input<FilterType>('all');
+  filterTag  = input<string | null>(null);
+  sortOrder  = input<SortOrder>('newest');
+  /** When set to an event id, that event is auto-expanded */
+  autoExpandId = input<string | null>(null);
+
+  /** Flat read-only view of the signal's current array */
+  readonly events = computed(() => this.eventsRef()());
+
+  readonly filtered = computed(() => {
+    const ft  = this.filterType();
+    const tag = this.filterTag();
+    const asc = this.sortOrder() === 'oldest';
+    return this.events()
+      .map((event, idx) => ({ event, idx }))
+      .filter(({ event }) => {
+        if (ft !== 'all' && event.type !== ft) return false;
+        if (tag && !parseTags(event.tags).includes(tag)) return false;
+        return true;
+      })
+      .sort((a, b) => {
+        const da = a.event.realDate || '0';
+        const db = b.event.realDate || '0';
+        return asc ? da.localeCompare(db) : db.localeCompare(da);
+      });
+  });
+
+  readonly allTags = computed((): string[] => {
+    const set = new Set<string>();
+    for (const e of this.events()) for (const t of parseTags(e.tags)) set.add(t);
+    return [...set].sort();
+  });
+
+  expandedIds = signal<Set<string>>(new Set());
+  confirmIdx  = signal<number | null>(null);
+
+  private tagInputMap     = signal<Record<string, string>>({});
+  private activeSuggIdxMap = signal<Record<string, number>>({});
+
+  readonly allExpanded = computed(() =>
+    this.events().length > 0 && this.events().every(e => this.expandedIds().has(e.id))
+  );
+
+  constructor() {
+    effect(() => {
+      const id = this.autoExpandId();
+      if (id) untracked(() => this.expandedIds.update(s => { const n = new Set(s); n.add(id); return n; }));
+    });
+  }
+
+  toggleExpand(id: string):  void { this.expandedIds.update(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; }); }
+  expandAll():               void { this.expandedIds.set(new Set(this.events().map(e => e.id))); }
+  collapseAll():             void { this.expandedIds.set(new Set()); }
+  toggleAllExpanded():       void { this.allExpanded() ? this.collapseAll() : this.expandAll(); }
+
+  cycleType(idx: number): void {
+    this.eventsRef().update(list => list.map((e, i) =>
+      i !== idx ? e : { ...e, type: TYPE_ORDER[(TYPE_ORDER.indexOf(e.type) + 1) % TYPE_ORDER.length] }
+    ));
+  }
+
+  askDelete(idx: number):  void { this.confirmIdx.set(idx); }
+  cancelDelete():          void { this.confirmIdx.set(null); }
+  confirmDelete():         void {
+    const idx = this.confirmIdx(); if (idx === null) return;
+    const id  = this.events()[idx]?.id;
+    if (id) this.expandedIds.update(s => { const n = new Set(s); n.delete(id); return n; });
+    this.eventsRef().update(list => list.filter((_, i) => i !== idx));
+    this.confirmIdx.set(null);
+  }
+
+  // ── Tags ──────────────────────────────────────────────────────────────────
+  getTagInput(id: string): string            { return this.tagInputMap()[id] ?? ''; }
+  setTagInput(id: string, val: string): void { this.tagInputMap.update(m => ({ ...m, [id]: val })); this.setActiveSuggIdx(id, -1); }
+  focusTagInput(id: string): void            { document.getElementById('tag-input-' + id)?.focus(); }
+
+  getActiveSuggIdx(id: string): number           { return this.activeSuggIdxMap()[id] ?? -1; }
+  setActiveSuggIdx(id: string, n: number): void  { this.activeSuggIdxMap.update(m => ({ ...m, [id]: n })); }
+
+  getTagSuggestions(eventId: string): Array<{ tag: string; html: string }> {
+    const rawQuery = this.getTagInput(eventId).trim();
+    if (!rawQuery) return [];
+    const query = posNorm(rawQuery);
+    const existingSet = new Set(parseTags(this.events().find(e => e.id === eventId)?.tags ?? ''));
+    return this.allTags()
+      .filter(tag => !existingSet.has(tag))
+      .map(tag => {
+        const indices = fuzzySubsequence(query, posNorm(tag));
+        if (!indices) return null;
+        return { tag, html: buildHighlightHtml(tag, indices) };
+      })
+      .filter((x): x is { tag: string; html: string } => x !== null);
+  }
+
+  selectSuggestion(idx: number, tag: string): void {
+    const id = this.events()[idx]?.id; if (!id) return;
+    const existing = parseTags(this.events()[idx].tags);
+    if (!existing.includes(tag)) {
+      this.eventsRef().update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...parseTags(e.tags), tag].join(' ') }));
+    }
+    this.setTagInput(id, ''); this.setActiveSuggIdx(id, -1);
+    document.getElementById('tag-input-' + id)?.focus();
+  }
+
+  navigateSuggestions(id: string, dir: 1 | -1): void {
+    const len = this.getTagSuggestions(id).length; if (!len) return;
+    this.setActiveSuggIdx(id, Math.max(-1, Math.min(len - 1, this.getActiveSuggIdx(id) + dir)));
+  }
+
+  onTagEnter(idx: number, id: string): void {
+    const ai = this.getActiveSuggIdx(id);
+    const suggestions = this.getTagSuggestions(id);
+    if (ai >= 0 && ai < suggestions.length) this.selectSuggestion(idx, suggestions[ai].tag);
+    else this.addTagFromInput(idx);
+  }
+
+  onTagBlur(idx: number): void {
+    const id = this.events()[idx]?.id; if (!id) return;
+    this.setActiveSuggIdx(id, -1);
+    const val = this.getTagInput(id).trim(); if (!val) return;
+    const existing = parseTags(this.events()[idx].tags);
+    if (!existing.includes(val)) {
+      this.eventsRef().update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...existing, val].join(' ') }));
+    }
+    this.setTagInput(id, '');
+  }
+
+  addTagFromInput(idx: number): void {
+    const id = this.events()[idx]?.id; if (!id) return;
+    const val = this.getTagInput(id).trim(); if (!val) return;
+    const existing = parseTags(this.events()[idx].tags);
+    if (!existing.includes(val)) {
+      this.eventsRef().update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: [...existing, val].join(' ') }));
+    }
+    this.setTagInput(id, ''); this.setActiveSuggIdx(id, -1);
+  }
+
+  removeTag(idx: number, tag: string): void {
+    this.eventsRef().update(list => list.map((e, i) => i !== idx ? e : { ...e, tags: parseTags(e.tags).filter(t => t !== tag).join(' ') }));
+  }
+
+  typeMeta(t: string) { return TYPE_META[t as keyof typeof TYPE_META] ?? TYPE_META['other']; }
+  parseTags = parseTags;
+}

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
@@ -24,13 +24,12 @@ import {
       background: linear-gradient(180deg, transparent, rgba(155,140,115,.28) 5%, rgba(155,140,115,.28) 95%, transparent);
     }
 
-    /* ── Timeline node — 12 px circle centered on line ── */
+    /* ── Timeline node — 12 px solid circle centered on line ── */
     .tl-node {
       position: absolute;
       left: -37px; top: 20px;
       width: 12px; height: 12px; border-radius: 50%;
-      border: 2px solid;
-      box-shadow: 0 0 6px currentColor;
+      border: 2px solid rgba(14,12,8,.96);
     }
 
     /* ── Event card ──────────────────────────────── */
@@ -173,8 +172,7 @@ import {
         <div class="event-card">
 
           <div class="tl-node"
-            [style.border-color]="typeMeta(item.event.type).color"
-            [style.background]="typeMeta(item.event.type).bg">
+            [style.background]="typeMeta(item.event.type).color">
           </div>
 
           <!-- Card header -->

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
@@ -17,13 +17,6 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormsModule, MatIcon, MatIconButton, MatTooltip, RichTextareaComponent],
   styles: `
-    /* ── pt-filter-btn icon support ─────────────── */
-    .pt-filter-btn { display: inline-flex; align-items: center; gap: 5px;
-      mat-icon, .mat-icon { font-size: 14px; width: 14px; height: 14px; } }
-
-    /* ── List toolbar ────────────────────────────── */
-    .sl-toolbar { display: flex; align-items: center; justify-content: flex-end; margin-bottom: 12px; min-height: 32px; }
-
     /* ── Timeline container ──────────────────────── */
     .timeline { position: relative; padding-left: 48px; }
     .timeline-line {
@@ -31,13 +24,13 @@ import {
       background: linear-gradient(180deg, transparent, rgba(155,140,115,.28) 5%, rgba(155,140,115,.28) 95%, transparent);
     }
 
-    /* ── Timeline node ─────────────────────────── */
+    /* ── Timeline node — 12 px circle centered on line ── */
     .tl-node {
-      position: absolute; left: -40px; top: 18px;
-      width: 28px; height: 28px; border-radius: 50%;
-      display: flex; align-items: center; justify-content: center;
-      border: 2px solid; background: rgba(14,12,8,.96);
-      mat-icon { font-size: 14px; width: 14px; height: 14px; }
+      position: absolute;
+      left: -37px; top: 20px;
+      width: 12px; height: 12px; border-radius: 50%;
+      border: 2px solid;
+      box-shadow: 0 0 6px currentColor;
     }
 
     /* ── Event card ──────────────────────────────── */
@@ -164,34 +157,24 @@ import {
     @keyframes scaleIn { from { transform: scale(.92); opacity: 0; } to { transform: scale(1); opacity: 1; } }
   `,
   template: `
-    <!-- Toolbar: expand/collapse all -->
-    <div class="sl-toolbar">
-      @if (events().length > 0) {
-        <button class="pt-filter-btn" type="button" (click)="toggleAllExpanded()"
-          [matTooltip]="allExpanded() ? 'Sbalit vše' : 'Rozbalit vše'">
-          <mat-icon>{{ allExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
-        </button>
-      }
-    </div>
+    @if (filtered().length === 0) {
+      <div class="empty-state">
+        <mat-icon>auto_stories</mat-icon>
+        @if (events().length === 0) { Žádné události — přidej první kapitolu příběhu. }
+        @else { Žádné události neodpovídají filtru. }
+      </div>
+    }
 
+    @if (filtered().length > 0) {
     <div class="timeline">
       <div class="timeline-line"></div>
-
-      @if (filtered().length === 0) {
-        <div class="empty-state">
-          <mat-icon>auto_stories</mat-icon>
-          @if (events().length === 0) { Žádné události — přidej první kapitolu příběhu. }
-          @else { Žádné události neodpovídají filtru. }
-        </div>
-      }
 
       @for (item of filtered(); track item.event.id) {
         <div class="event-card">
 
           <div class="tl-node"
             [style.border-color]="typeMeta(item.event.type).color"
-            [style.color]="typeMeta(item.event.type).color">
-            <mat-icon>{{ typeMeta(item.event.type).icon }}</mat-icon>
+            [style.background]="typeMeta(item.event.type).bg">
           </div>
 
           <!-- Card header -->
@@ -314,6 +297,7 @@ import {
         </div>
       }
     </div>
+    }
 
     @if (confirmIdx() !== null) {
       <div class="confirm-backdrop" (click)="cancelDelete()">

--- a/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/dm-story-timeline/story-events-list.component.ts
@@ -224,7 +224,7 @@ import {
 
               <div class="field-row">
                 <div class="field-group" style="flex:1;min-width:200px">
-                  <div class="field-label">Název události</div>
+                  <div class="field-label" style="margin-top: 11px;">Název události</div>
                   <input class="field-input" [(ngModel)]="events()[item.idx].title" placeholder="Název…" [disabled]="isReadOnly()" />
                 </div>
               </div>
@@ -285,7 +285,7 @@ import {
 
               <div>
                 <div class="rt-label">Shrnutí události</div>
-                <div class="rt-wrap">
+                <div class="rt-wrap" style="margin-top: 10px;">
                   <rich-textarea [(ngModel)]="events()[item.idx].summary" style="position:absolute;top:0;left:0;width:100%;height:100%;"></rich-textarea>
                 </div>
               </div>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/monsters-tab/monster-detail-dialog.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/monsters-tab/monster-detail-dialog.component.ts
@@ -31,11 +31,10 @@ export interface FamilyLoreDialogData {
   imports: [MatIcon],
   styles: `
     :host { font-family: sans-serif; display: block; }
-    .dlg { display: flex; flex-direction: column; max-height: 82vh; width: min(860px, 96vw); background: #0b0a18; color: #d4c9a0; overflow: hidden; }
-    .dlg-header { display: flex; align-items: center; justify-content: space-between; padding: 14px 20px 12px; flex-shrink: 0; border-bottom: 1px solid rgba(200,160,60,.25); background: linear-gradient(180deg, rgba(28,18,4,.9) 0%, rgba(10,8,20,.9) 100%); gap: 12px; }
-    .dlg-title { display: flex; align-items: center; gap: 10px; font-size: 17px; letter-spacing: .1em; text-transform: uppercase; color: #e8c96a; text-shadow: 0 0 18px rgba(200,160,60,.5); flex: 1; min-width: 0; }
-    .dlg-title mat-icon { font-size: 20px; width: 20px; height: 20px; color: #c8a03c; flex-shrink: 0; }
-    .dlg-close { background: none; border: 1px solid rgba(200,160,60,.25); border-radius: 4px; color: rgba(200,160,60,.6); cursor: pointer; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; padding: 0; transition: all .18s; flex-shrink: 0; mat-icon { font-size: 18px; width: 18px; height: 18px; } &:hover { background: rgba(200,160,60,.12); color: #e8c96a; border-color: rgba(200,160,60,.6); } }
+    .dlg { display: flex; flex-direction: column; max-height: 82vh; width: min(860px, 96vw); background: #0c0a08; color: #d4c9a0; overflow: hidden; }
+    .dlg-header { display: flex; align-items: center; justify-content: space-between; padding: 8px 14px; flex-shrink: 0; border-bottom: 1px solid rgba(200,160,60,.25); background: linear-gradient(90deg, rgba(12,10,8,.98) 0%, rgba(20,16,13,.98) 100%); gap: 12px; }
+    .dlg-title { font-size: 14px; font-family: sans-serif; letter-spacing: .06em; color: #e0d4c0; flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .dlg-close { background: transparent; border: 1px solid rgba(200,160,60,.25); border-radius: 4px; color: rgba(200,160,60,.55); cursor: pointer; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center; padding: 0; transition: all .15s; flex-shrink: 0; mat-icon { font-size: 16px; width: 16px; height: 16px; } &:hover { background: rgba(200,160,60,.1); color: #e8c96a; border-color: rgba(200,160,60,.5); } }
     .dlg-body { flex: 1; overflow-y: auto; padding: 20px 24px 24px; scrollbar-width: thin; scrollbar-color: rgba(200,160,60,.25) transparent; }
     .dlg-loading { padding: 60px 24px; text-align: center; font-size: 13px; color: rgba(200,160,60,.3); font-style: italic; mat-icon { display: block; font-size: 38px; width: 38px; height: 38px; margin: 0 auto 14px; color: rgba(200,160,60,.18); } }
     :host ::ng-deep h1, :host ::ng-deep h2, :host ::ng-deep h3 { color: #c8903c; letter-spacing: .06em; margin-top: 18px; margin-bottom: 6px; }
@@ -47,10 +46,7 @@ export interface FamilyLoreDialogData {
   template: `
     <div class="dlg">
       <div class="dlg-header">
-        <div class="dlg-title">
-          <mat-icon>menu_book</mat-icon>
-          <span>{{ data.familyTitle }}</span>
-        </div>
+        <div class="dlg-title">{{ data.familyTitle }}</div>
         <button type="button" class="dlg-close" (click)="dialogRef.close()" aria-label="Zavřít">
           <mat-icon>close</mat-icon>
         </button>
@@ -94,30 +90,28 @@ export class FamilyLoreDialogComponent {
     .dlg {
       display: flex; flex-direction: column;
       max-height: 82vh; width: min(860px, 96vw);
-      background: #0b0a18; color: #d4c9a0; overflow: hidden;
+      background: #0c0a08; color: #d4c9a0; overflow: hidden;
     }
 
     .dlg-header {
       display: flex; align-items: center; justify-content: space-between;
-      padding: 14px 20px 12px; flex-shrink: 0;
+      padding: 8px 14px; flex-shrink: 0;
       border-bottom: 1px solid rgba(200,160,60,.25);
-      background: linear-gradient(180deg, rgba(28,18,4,.9) 0%, rgba(10,8,20,.9) 100%);
+      background: linear-gradient(90deg, rgba(12,10,8,.98) 0%, rgba(20,16,13,.98) 100%);
       gap: 12px;
     }
     .dlg-title {
-      display: flex; align-items: center; gap: 10px;
-      font-size: 17px; letter-spacing: .1em; text-transform: uppercase;
-      color: #e8c96a; text-shadow: 0 0 18px rgba(200,160,60,.5);
-      flex: 1; min-width: 0;
+      font-size: 14px; font-family: sans-serif; letter-spacing: .06em;
+      color: #e0d4c0;
+      flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
-    .dlg-title mat-icon { font-size: 20px; width: 20px; height: 20px; color: #c8a03c; flex-shrink: 0; }
-    .dlg-subtitle { font-size: 11px; letter-spacing: .05em; color: rgba(200,160,60,.45); text-transform: none; }
+    .dlg-subtitle { font-size: 11px; letter-spacing: .05em; color: rgba(200,160,60,.45); display: block; }
     .dlg-close {
-      background: none; border: 1px solid rgba(200,160,60,.25); border-radius: 4px;
-      color: rgba(200,160,60,.6); cursor: pointer; width: 32px; height: 32px;
+      background: transparent; border: 1px solid rgba(200,160,60,.25); border-radius: 4px;
+      color: rgba(200,160,60,.55); cursor: pointer; width: 26px; height: 26px;
       display: flex; align-items: center; justify-content: center; padding: 0;
-      transition: all .18s; flex-shrink: 0;
-      mat-icon { font-size: 18px; width: 18px; height: 18px; }
+      transition: all .15s; flex-shrink: 0;
+      mat-icon { font-size: 16px; width: 16px; height: 16px; }
       &:hover { background: rgba(200,160,60,.12); color: #e8c96a; border-color: rgba(200,160,60,.6); }
     }
 
@@ -202,11 +196,10 @@ export class FamilyLoreDialogComponent {
     <div class="dlg">
       <div class="dlg-header">
         <div class="dlg-title">
-          <mat-icon>pets</mat-icon>
           <span>
             {{ monsterName }}
             @if (monsterSubtitle()) {
-              <div class="dlg-subtitle">{{ monsterSubtitle() }}</div>
+              <span class="dlg-subtitle">{{ monsterSubtitle() }}</span>
             }
           </span>
         </div>

--- a/libs/dm-page/feature/src/lib/dm-page-feature/monsters-tab/monsters-tab.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/monsters-tab/monsters-tab.component.ts
@@ -101,6 +101,7 @@ const CR_RANGES: CrRange[] = [
   selector: 'monsters-tab',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MatIcon, MatTooltip],
+  host: { '(document:keydown)': 'onDocKeydown($event)' },
   styles: `
     :host {
       display: flex; flex-direction: column;
@@ -114,23 +115,45 @@ const CR_RANGES: CrRange[] = [
       border-bottom: 1px solid rgba(200,160,60,.22);
       background: linear-gradient(180deg, rgba(22,15,5,.97) 0%, rgba(14,10,4,.98) 100%);
     }
-    .search-wrap {
-      flex: 1; position: relative; display: flex; align-items: center;
-      .search-icon { position: absolute; left: 10px; font-size: 18px; width: 18px; height: 18px; color: rgba(200,160,60,.45); pointer-events: none; }
+
+    /* ── Wiki-style search ── */
+    .search-wrap { flex: 1; position: relative; }
+    .search-row {
+      display: flex; align-items: center; gap: 9px;
+      padding: 8px 14px;
+      background: rgba(22,12,4,.97);
+      border: 1px solid rgba(200,160,60,.22);
+      border-radius: 4px; position: relative;
+      transition: border-color .15s, box-shadow .15s;
+      &:focus-within {
+        border-color: rgba(200,160,60,.52);
+        box-shadow: 0 0 0 2px rgba(200,160,60,.1);
+      }
     }
+    .search-hint {
+      position: absolute; left: 43px; top: 50%; transform: translateY(-50%);
+      display: flex; align-items: center; gap: 5px;
+      font-family: sans-serif; font-size: 13px; color: rgba(200,160,60,.32);
+      pointer-events: none; user-select: none; white-space: nowrap;
+    }
+    .search-hint__kbd {
+      display: inline-flex; align-items: center; justify-content: center;
+      font-family: monospace; font-size: 11px; line-height: 1;
+      padding: 2px 6px; border: 1px solid rgba(200,160,60,.35); border-radius: 3px;
+      background: rgba(200,160,60,.08); color: rgba(200,160,60,.6);
+      box-shadow: 0 1px 0 rgba(200,160,60,.2);
+    }
+    .search-icon { color: #6a5a48; flex-shrink: 0; }
     .search {
-      width: 100%; background: rgba(5,3,12,.75); border: 1px solid rgba(200,160,60,.28);
-      border-radius: 4px; color: #d4c9a0; font-family: sans-serif; font-size: 13px;
-      padding: 7px 34px; outline: none; transition: border-color .18s, box-shadow .18s;
-      &::placeholder { color: rgba(200,160,60,.28); font-style: italic; }
-      &:focus { border-color: rgba(200,160,60,.6); box-shadow: 0 0 10px rgba(200,160,60,.12); }
+      flex: 1; background: transparent; border: none; outline: none;
+      font-family: sans-serif; font-size: 14px; color: #c8baa8; min-width: 0;
+      &::placeholder { color: #4a3a28; }
     }
     .search-clear {
-      position: absolute; right: 6px; background: none; border: none; cursor: pointer;
-      color: rgba(200,160,60,.45); display: flex; align-items: center;
-      padding: 2px; border-radius: 3px; transition: color .15s;
-      mat-icon { font-size: 16px; width: 16px; height: 16px; }
-      &:hover { color: #e8c96a; }
+      background: transparent; border: none; padding: 0; cursor: pointer;
+      color: #4a3a28; display: flex; align-items: center; flex-shrink: 0;
+      transition: color .12s;
+      &:hover { color: #c8a03c; }
     }
     .count { font-family: sans-serif; font-size: 11px; color: rgba(200,160,60,.35); white-space: nowrap; flex-shrink: 0; }
 
@@ -217,20 +240,33 @@ const CR_RANGES: CrRange[] = [
     <!-- Search -->
     <div class="header">
       <div class="search-wrap">
-        <mat-icon class="search-icon">search</mat-icon>
-        <input
-          #searchInput
-          class="search"
-          [value]="searchQuery()"
-          (input)="searchQuery.set($any($event.target).value)"
-          placeholder="Hledat netvora&#8230;"
-          autocomplete="off" spellcheck="false"
-        />
-        @if (searchQuery()) {
-          <button class="search-clear" type="button" (click)="searchQuery.set('')" matTooltip="Vymazat">
-            <mat-icon>close</mat-icon>
-          </button>
-        }
+        <div class="search-row">
+          <svg class="search-icon" viewBox="0 0 24 24" width="17" height="17" fill="currentColor" aria-hidden="true">
+            <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+          </svg>
+          <input
+            #searchInput
+            class="search"
+            [value]="searchQuery()"
+            (input)="searchQuery.set($any($event.target).value)"
+            (focus)="searchFocused.set(true)"
+            (blur)="searchFocused.set(false)"
+            placeholder=""
+            autocomplete="off" spellcheck="false"
+          />
+          @if (!searchQuery() && !searchFocused()) {
+            <span class="search-hint" aria-hidden="true">
+              <kbd class="search-hint__kbd">/</kbd> pro vyhledávání
+            </span>
+          }
+          @if (searchQuery()) {
+            <button class="search-clear" type="button" (click)="clearSearch()" title="Vymazat">
+              <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor">
+                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+              </svg>
+            </button>
+          }
+        </div>
       </div>
       <span class="count">{{ filtered().length }}&thinsp;/&thinsp;{{ monstersService.allMonsters().length }}</span>
     </div>
@@ -322,6 +358,7 @@ export class MonstersTabComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   readonly searchQuery = signal('');
+  readonly searchFocused = signal(false);
   readonly selectedType = signal<string | null>(null);
   readonly selectedCrRange = signal<string | null>(null);
   readonly sortMode = signal<'type' | 'cr'>('type');
@@ -402,6 +439,24 @@ export class MonstersTabComponent {
 
   toggleCrRange(label: string): void {
     this.selectedCrRange.update(cur => (cur === label ? null : label));
+  }
+
+  clearSearch(): void {
+    this.searchQuery.set('');
+    this._searchRef()?.nativeElement.focus();
+  }
+
+  /** Focus the search input when '/' is pressed outside any text field. */
+  onDocKeydown(event: KeyboardEvent): void {
+    if (event.key !== '/') return;
+    const active = document.activeElement;
+    if (
+      active instanceof HTMLInputElement ||
+      active instanceof HTMLTextAreaElement ||
+      (active as HTMLElement)?.isContentEditable
+    ) return;
+    event.preventDefault();
+    this._searchRef()?.nativeElement.focus();
   }
 
   cardTooltip(m: JadMonster): string {

--- a/libs/dm-page/feature/src/lib/dm-page-feature/monsters-tab/monsters-tab.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/monsters-tab/monsters-tab.component.ts
@@ -121,7 +121,7 @@ const CR_RANGES: CrRange[] = [
     .search-row {
       display: flex; align-items: center; gap: 9px;
       padding: 8px 14px;
-      background: rgba(22,12,4,.97);
+      background: rgba(200,160,60,.07);
       border: 1px solid rgba(200,160,60,.22);
       border-radius: 4px; position: relative;
       transition: border-color .15s, box-shadow .15s;

--- a/libs/dm-page/feature/src/lib/dm-page-feature/monsters-tab/monsters-tab.component.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-feature/monsters-tab/monsters-tab.component.ts
@@ -145,30 +145,8 @@ const CR_RANGES: CrRange[] = [
       text-transform: uppercase; color: rgba(200,160,60,.35);
       flex-shrink: 0; margin-right: 2px;
     }
-    .chip {
-      padding: 2px 10px; border: 1px solid rgba(200,160,60,.25); border-radius: 12px;
-      background: none; color: rgba(200,160,60,.5); font-family: sans-serif; font-size: 11px;
-      cursor: pointer; transition: all .15s; white-space: nowrap;
-      &:hover { border-color: rgba(200,160,60,.55); color: #d4c9a0; background: rgba(200,160,60,.07); }
-      &.active { background: rgba(200,160,60,.14); border-color: #c8a03c; color: #e8c96a; box-shadow: 0 0 7px rgba(200,160,60,.18); }
-    }
-    /* CR chips use a red/orange tint to visually distinguish from type chips */
-    .chip--cr {
-      border-color: rgba(200,80,60,.3); color: rgba(220,120,80,.6);
-      &:hover { border-color: rgba(220,120,80,.6); color: #e8a070; background: rgba(200,80,60,.07); }
-      &.active { background: rgba(200,80,60,.18); border-color: rgba(220,120,80,.8); color: #f0a070; box-shadow: 0 0 7px rgba(200,80,60,.2); }
-    }
     .sort-toggle {
-      margin-left: auto; flex-shrink: 0; display: flex;
-      border: 1px solid rgba(200,160,60,.22); border-radius: 12px; overflow: hidden;
-    }
-    .sort-btn {
-      padding: 2px 9px; background: none; border: none; color: rgba(200,160,60,.4);
-      font-family: sans-serif; font-size: 11px; cursor: pointer;
-      transition: background .15s, color .15s; white-space: nowrap;
-      &:hover { background: rgba(200,160,60,.07); color: rgba(200,160,60,.75); }
-      &.active { background: rgba(200,160,60,.14); color: #e8c96a; }
-      & + & { border-left: 1px solid rgba(200,160,60,.22); }
+      margin-left: auto; flex-shrink: 0; display: flex; gap: 4px;
     }
 
     /* ── Scroll area ── */
@@ -261,14 +239,14 @@ const CR_RANGES: CrRange[] = [
     @if (monstersService.availableTypes().length > 0) {
       <div class="filters">
         <span class="filter-label">Typ</span>
-        <button class="chip" [class.active]="selectedType() === null" type="button" (click)="selectedType.set(null)">Vše</button>
+        <button class="pt-filter-btn" [class.active]="selectedType() === null" type="button" (click)="selectedType.set(null)">Vše</button>
         @for (t of monstersService.availableTypes(); track t) {
-          <button class="chip" [class.active]="selectedType() === t" type="button" (click)="toggleType(t)">{{ t }}</button>
+          <button class="pt-filter-btn" [class.active]="selectedType() === t" type="button" (click)="toggleType(t)">{{ t }}</button>
         }
         <div class="sort-toggle" role="group" aria-label="Řazení">
-          <button class="sort-btn" [class.active]="sortMode() === 'type'" type="button"
+          <button class="pt-filter-btn" [class.active]="sortMode() === 'type'" type="button"
             (click)="sortMode.set('type')" matTooltip="Řadit podle typu">Typ</button>
-          <button class="sort-btn" [class.active]="sortMode() === 'cr'" type="button"
+          <button class="pt-filter-btn" [class.active]="sortMode() === 'cr'" type="button"
             (click)="sortMode.set('cr')" matTooltip="Řadit podle nebezpečnosti">NB</button>
         </div>
       </div>
@@ -278,10 +256,10 @@ const CR_RANGES: CrRange[] = [
     @if (availableCrRanges().length > 0) {
       <div class="filters">
         <span class="filter-label">NB</span>
-        <button class="chip chip--cr" [class.active]="selectedCrRange() === null" type="button" (click)="selectedCrRange.set(null)">Vše</button>
+        <button class="pt-filter-btn pt-filter-btn--cr" [class.active]="selectedCrRange() === null" type="button" (click)="selectedCrRange.set(null)">Vše</button>
         @for (range of availableCrRanges(); track range.label) {
           <button
-            class="chip chip--cr"
+            class="pt-filter-btn pt-filter-btn--cr"
             [class.active]="selectedCrRange() === range.label"
             type="button"
             (click)="toggleCrRange(range.label)"

--- a/libs/dm-page/feature/src/lib/dm-page-models.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-models.ts
@@ -37,10 +37,6 @@ export interface DmNotesApiModel {
   worldNotes: string;
   /** Secrets, plot twists, hidden information */
   secrets: string;
-  /** NPC & faction descriptions, relationships */
-  npcsAndFactions: string;
-  /** Treasure, magic items, rewards to hand out */
-  rewards: string;
 }
 
 // ── Story Timeline ─────────────────────────────────────────────────────────

--- a/libs/dm-page/feature/src/lib/dm-page-models.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-models.ts
@@ -41,28 +41,24 @@ export interface DmNotesApiModel {
 
 // ── Story Timeline ─────────────────────────────────────────────────────────
 
-export type StoryEventType = 'battle' | 'discovery' | 'npc_met' | 'milestone' | 'loss' | 'other';
-export type StoryEventImportance = 'minor' | 'major' | 'epic';
+export type StoryEventType = 'world' | 'campaign' | 'character' | 'other';
 
 export interface StoryEvent {
   id: string;
-  /** Short headline shown on the timeline card */
   title: string;
-  /** In-game calendar date (free text, e.g. "15. Flamerule 1492 DR") */
+  /** Kept for backward-compat with existing DB records — no longer shown in UI */
   inGameDate: string;
   /** ISO date string — used for chronological ordering */
   realDate: string;
   type: StoryEventType;
-  importance: StoryEventImportance;
-  /** Rich-text — public event summary */
+  /** Kept for backward-compat with existing DB records — no longer used in UI */
+  importance?: string;
   summary: string;
-  /** Rich-text — DM-only notes / secrets */
+  /** Kept for backward-compat — no longer editable in UI */
   dmNotes: string;
-  /** Base64 image (max 200 KB), null when absent */
+  /** Kept for backward-compat — no longer editable in UI */
   imageBase64: string | null;
-  /** Free-text location label */
   location: string;
-  /** Comma-separated tag labels */
   tags: string;
 }
 

--- a/libs/dm-page/feature/src/lib/dm-page-models.ts
+++ b/libs/dm-page/feature/src/lib/dm-page-models.ts
@@ -65,5 +65,12 @@ export interface StoryEvent {
 export interface DmStoryTimelineApiModel {
   username: string;
   events: StoryEvent[];
+  /** Usernames of players allowed to view this timeline (read-only) */
+  sharedWith?: string[];
+}
+
+export interface TimelineInvitationModel {
+  viewerUsername: string;
+  ownerUsername: string;
 }
 

--- a/libs/dm-page/feature/src/lib/dm-page.store.ts
+++ b/libs/dm-page/feature/src/lib/dm-page.store.ts
@@ -41,7 +41,7 @@ export const DmPageStore = signalStore(
             tapResponse(
               () => {
                 patchState(store, { dmQuests: req, loading: false });
-                snack.open('📖 DM questy uloženy!', '✕', { verticalPosition: 'top', duration: 2200, panelClass: ['snackbar--save'] });
+                snack.open('Data uložena', '✕', { verticalPosition: 'top', duration: 2200, panelClass: ['snackbar--save'] });
               },
               (e: HttpErrorResponse) => {
                 snack.open('Ukládání DM questů selhalo: ' + e.message, 'Zavřít', { verticalPosition: 'top', duration: 3000 });
@@ -78,7 +78,7 @@ export const DmPageStore = signalStore(
             tapResponse(
               () => {
                 patchState(store, { dmNotes: req, loading: false });
-                snack.open('📜 Poznámky PH uloženy!', '✕', { verticalPosition: 'top', duration: 2200, panelClass: ['snackbar--save'] });
+                snack.open('Data uložena', '✕', { verticalPosition: 'top', duration: 2200, panelClass: ['snackbar--save'] });
               },
               (e: HttpErrorResponse) => {
                 snack.open('Ukládání poznámek selhalo: ' + e.message, 'Zavřít', { verticalPosition: 'top', duration: 3000 });
@@ -115,7 +115,7 @@ export const DmPageStore = signalStore(
             tapResponse(
               () => {
                 patchState(store, { dmStoryTimeline: req, loading: false });
-                snack.open('📖 Příběhové události uloženy!', '✕', { verticalPosition: 'top', duration: 2200, panelClass: ['snackbar--save'] });
+                snack.open('Data uložena', '✕', { verticalPosition: 'top', duration: 2200, panelClass: ['snackbar--save'] });
               },
               (e: HttpErrorResponse) => {
                 snack.open('Ukládání příběhové osy selhalo: ' + e.message, 'Zavřít', { verticalPosition: 'top', duration: 3000 });

--- a/libs/ui/src/lib/rich-textarea.component.ts
+++ b/libs/ui/src/lib/rich-textarea.component.ts
@@ -147,11 +147,11 @@ function parseMarkup(raw: string): string {
       flex-wrap: wrap;
       gap: 2px;
       align-items: center;
-      background: #fff;
-      border: 1px solid #ccc;
+      background: rgba(18, 12, 5, 0.97);
+      border: 1px solid rgba(200, 160, 60, 0.3);
       border-radius: 4px;
       padding: 2px 4px;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.7);
       white-space: nowrap;
 
       button {
@@ -164,7 +164,8 @@ function parseMarkup(raw: string): string {
         font-size: 13px;
         padding: 0 4px;
         line-height: 1;
-        &:hover { background: #f0f0f0; border-color: #bbb; }
+        color: rgba(220, 195, 130, 0.85);
+        &:hover { background: rgba(200, 160, 60, 0.14); border-color: rgba(200, 160, 60, 0.4); color: #e8c96a; }
       }
     }
 
@@ -178,8 +179,8 @@ function parseMarkup(raw: string): string {
       border-radius: 6px 6px 0 0;
       border-bottom: none;
       box-shadow: none;
-      background: #f8f5ee;
-      border-color: rgba(180, 130, 50, 0.35);
+      background: rgba(18, 12, 5, 0.97);
+      border-color: rgba(200, 160, 60, 0.3);
       flex-wrap: wrap;
       gap: 4px;
       padding: 6px 8px;
@@ -193,14 +194,14 @@ function parseMarkup(raw: string): string {
     }
 
     .rt-done-btn {
-      color: #2a6e2a !important;
+      color: rgba(100, 200, 100, 0.9) !important;
       font-weight: bold !important;
       font-size: 16px !important;
       min-width: 32px !important;
-      &:hover { background: rgba(40,140,40,0.12) !important; border-color: #4caf50 !important; }
+      &:hover { background: rgba(50, 160, 50, 0.15) !important; border-color: rgba(80, 180, 80, 0.5) !important; }
     }
 
-    .rt-separator { width: 1px; height: 18px; background: #ccc; margin: 0 2px; flex-shrink: 0; }
+    .rt-separator { width: 1px; height: 18px; background: rgba(200, 160, 60, 0.25); margin: 0 2px; flex-shrink: 0; }
 
     /* ── Preview ─────────────────────────────────────────────────────── */
     .rt-preview {

--- a/libs/util/src/lib/local-storage-keys.ts
+++ b/libs/util/src/lib/local-storage-keys.ts
@@ -72,4 +72,7 @@ export const CS_SPELLS_FIRST_KEY = 'cs-spells-page-first';
 /** Last viewed wiki position (book + chapter) */
 export const WIKI_LAST_POSITION_KEY = 'wiki-last-position';
 
+/** Whether the "Obsah kapitoly" (chapter TOC) accordion is expanded (true) or collapsed (false). */
+export const WIKI_TOC_OPEN_KEY = 'wiki-toc-open';
+
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -289,9 +289,9 @@
 .toolbar {
   font-family: 'Mikadan', sans-serif;
   background:
-    linear-gradient(90deg, rgba(10,4,4,.98) 0%, rgba(18,8,6,.98) 40%, rgba(18,8,6,.98) 60%, rgba(10,4,4,.98) 100%),
+    linear-gradient(90deg, rgba(14,2,2,.98) 0%, rgba(24,4,4,.98) 40%, rgba(24,4,4,.98) 60%, rgba(14,2,2,.98) 100%),
     url('https://www.transparenttextures.com/patterns/dark-leather.png') !important;
-  background-color: #0a0504 !important;
+  background-color: #0d0202 !important;
   border-bottom: 1px solid rgba(200,160,60,.35) !important;
   box-shadow: 0 3px 28px rgba(0,0,0,.85), inset 0 -1px 0 rgba(200,160,60,.18) !important;
   color: #e0d4c0 !important;
@@ -570,9 +570,9 @@
   z-index: 201;
   min-width: 200px;
   background:
-    linear-gradient(180deg, rgba(10,5,4,.99) 0%, rgba(18,8,6,.99) 100%),
+    linear-gradient(180deg, rgba(14,2,2,.99) 0%, rgba(20,4,4,.99) 100%),
     url('https://www.transparenttextures.com/patterns/dark-leather.png');
-  background-color: #0a0504;
+  background-color: #0d0202;
   border: 1px solid rgba(200,160,60,.35);
   border-radius: 8px;
   box-shadow: 0 8px 32px rgba(0,0,0,.85), 0 0 0 1px rgba(200,160,60,.12);
@@ -584,7 +584,7 @@
     top: -7px; right: 14px;
     font-size: 9px;
     color: rgba(200,160,60,.6);
-    background: #0a0504;
+    background: #0d0202;
     padding: 0 2px;
     pointer-events: none;
   }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -289,9 +289,9 @@
 .toolbar {
   font-family: 'Mikadan', sans-serif;
   background:
-    linear-gradient(90deg, rgba(8,5,16,.98) 0%, rgba(16,11,26,.98) 40%, rgba(16,11,26,.98) 60%, rgba(8,5,16,.98) 100%),
+    linear-gradient(90deg, rgba(10,4,4,.98) 0%, rgba(18,8,6,.98) 40%, rgba(18,8,6,.98) 60%, rgba(10,4,4,.98) 100%),
     url('https://www.transparenttextures.com/patterns/dark-leather.png') !important;
-  background-color: #0a0712 !important;
+  background-color: #0a0504 !important;
   border-bottom: 1px solid rgba(200,160,60,.35) !important;
   box-shadow: 0 3px 28px rgba(0,0,0,.85), inset 0 -1px 0 rgba(200,160,60,.18) !important;
   color: #e0d4c0 !important;
@@ -351,12 +351,12 @@
   margin-left: auto;
   flex: 0 0 auto;
   font-size: 10px;
-  color: #8a8090;
+  color: #8a7870;
   gap: 4px;
 }
 
 .toolbar-label {
-  color: #6b6070;
+  color: #6b5f58;
   font-size: 10px;
   letter-spacing: .04em;
 }
@@ -389,6 +389,10 @@
 
 .author-link {
   font-size: 16px;
+
+  @media (min-width: 901px) {
+    margin-right: 13px;
+  }
 }
 
 .backup-btn {
@@ -481,25 +485,16 @@
   }
 }
 
-@keyframes menu-pulse {
-  0%, 100% { box-shadow: 0 0 6px rgba(200,160,60,.4), 0 0 0 1px rgba(200,160,60,.25); }
-  50%       { box-shadow: 0 0 14px rgba(200,160,60,.7), 0 0 0 1px rgba(200,160,60,.5); }
-}
-
 .menu-btn {
-  color: #c8a03c !important;
+  color: #a08060 !important;
   border-radius: 6px !important;
-  border: 1px solid rgba(200,160,60,.3) !important;
-  background: rgba(200,160,60,.08) !important;
-  animation: menu-pulse 2.8s ease-in-out infinite;
-  transition: background .18s, border-color .18s, transform .12s !important;
+  background: transparent !important;
+  border: none !important;
+  transition: color .15s !important;
 
   &:hover {
-    background: rgba(200,160,60,.18) !important;
-    border-color: rgba(200,160,60,.7) !important;
-    transform: scale(1.08);
-    animation: none;
-    box-shadow: 0 0 18px rgba(200,160,60,.5);
+    color: #c8a03c !important;
+    background: rgba(200,160,60,.08) !important;
   }
 
   mat-icon { font-size: 22px; }
@@ -513,7 +508,7 @@
 
 .author-info {
   font-size: 10px;
-  color: #8a8090;
+  color: #8a7870;
 }
 
 .link {
@@ -575,9 +570,9 @@
   z-index: 201;
   min-width: 200px;
   background:
-    linear-gradient(180deg, rgba(8,5,16,.99) 0%, rgba(18,12,28,.99) 100%),
+    linear-gradient(180deg, rgba(10,5,4,.99) 0%, rgba(18,8,6,.99) 100%),
     url('https://www.transparenttextures.com/patterns/dark-leather.png');
-  background-color: #0d0910;
+  background-color: #0a0504;
   border: 1px solid rgba(200,160,60,.35);
   border-radius: 8px;
   box-shadow: 0 8px 32px rgba(0,0,0,.85), 0 0 0 1px rgba(200,160,60,.12);
@@ -589,7 +584,7 @@
     top: -7px; right: 14px;
     font-size: 9px;
     color: rgba(200,160,60,.6);
-    background: #0d0910;
+    background: #0a0504;
     padding: 0 2px;
     pointer-events: none;
   }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -10,7 +10,7 @@
   min-height: 100dvh;
   min-width: 100vw;
   // Ensure the dark wallpaper covers everything even when content is short
-  background-color: #0a0710;
+  background-color: #080504;
   // Override Bootstrap's .container padding so the toolbar fills full width
   padding-left: 0 !important;
   padding-right: 0 !important;
@@ -29,9 +29,9 @@
 .sidenav {
   width: 280px !important;
   background:
-    linear-gradient(180deg, rgba(8,5,16,.97) 0%, rgba(18,12,28,.97) 60%, rgba(8,5,16,.97) 100%),
+    linear-gradient(180deg, rgba(10,5,4,.97) 0%, rgba(16,8,6,.97) 60%, rgba(10,5,4,.97) 100%),
     url('https://www.transparenttextures.com/patterns/dark-leather.png') !important;
-  background-color: #0d0910 !important;
+  background-color: #0a0604 !important;
   border-right: none !important;
   box-shadow: 4px 0 32px rgba(0,0,0,.8), inset -1px 0 0 rgba(200,160,60,.25) !important;
   overflow: hidden;
@@ -90,7 +90,7 @@
 
 .sidenav__subtitle {
   font-size: 11px;
-  color: #6b6070;
+  color: #6b6058;
   letter-spacing: .12em;
   text-transform: uppercase;
 }
@@ -164,7 +164,7 @@
     font-size: 20px;
     width: 20px;
     height: 20px;
-    color: #6b6080;
+    color: #6b6058;
     transition: color .18s;
   }
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -249,20 +249,6 @@
     z-index: 1;
   }
 
-  &::before {
-    content: '◆';
-    position: absolute;
-    bottom: -7px; left: 50%;
-    transform: translateX(-50%);
-    font-size: 9px;
-    color: rgba(200,160,60,.5);
-    text-shadow: 0 0 8px rgba(200,160,60,.4);
-    background: rgba(14,11,8,1);
-    padding: 0 8px;
-    pointer-events: none;
-    z-index: 1;
-  }
-
   > * { flex: 1; min-height: 0; }
 }
 
@@ -312,16 +298,6 @@
     height: 1px;
     background: linear-gradient(90deg, transparent, rgba(200,160,60,.6), transparent);
     pointer-events: none;
-  }
-
-  &::before {
-    content: '◆';
-    position: absolute;
-    bottom: -6px; left: calc(50% - 6px);
-    font-size: 9px;
-    color: rgba(200,160,60,.55);
-    pointer-events: none;
-    line-height: 1;
   }
 
   span {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -289,9 +289,9 @@
 .toolbar {
   font-family: 'Mikadan', sans-serif;
   background:
-    linear-gradient(90deg, rgba(14,2,2,.98) 0%, rgba(24,4,4,.98) 40%, rgba(24,4,4,.98) 60%, rgba(14,2,2,.98) 100%),
+    linear-gradient(90deg, rgba(12,10,8,.98) 0%, rgba(20,16,13,.98) 40%, rgba(20,16,13,.98) 60%, rgba(12,10,8,.98) 100%),
     url('https://www.transparenttextures.com/patterns/dark-leather.png') !important;
-  background-color: #0d0202 !important;
+  background-color: #0c0a08 !important;
   border-bottom: 1px solid rgba(200,160,60,.35) !important;
   box-shadow: 0 3px 28px rgba(0,0,0,.85), inset 0 -1px 0 rgba(200,160,60,.18) !important;
   color: #e0d4c0 !important;
@@ -570,9 +570,9 @@
   z-index: 201;
   min-width: 200px;
   background:
-    linear-gradient(180deg, rgba(14,2,2,.99) 0%, rgba(20,4,4,.99) 100%),
+    linear-gradient(180deg, rgba(10,5,4,.99) 0%, rgba(16,8,6,.99) 100%),
     url('https://www.transparenttextures.com/patterns/dark-leather.png');
-  background-color: #0d0202;
+  background-color: #0a0604;
   border: 1px solid rgba(200,160,60,.35);
   border-radius: 8px;
   box-shadow: 0 8px 32px rgba(0,0,0,.85), 0 0 0 1px rgba(200,160,60,.12);
@@ -584,7 +584,7 @@
     top: -7px; right: 14px;
     font-size: 9px;
     color: rgba(200,160,60,.6);
-    background: #0d0202;
+    background: #0a0604;
     padding: 0 2px;
     pointer-events: none;
   }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -337,8 +337,8 @@ export class App implements OnInit, OnDestroy {
   // ── Two-finger swipe ─────────────────────────────────────
 
   private onTouchStart(e: TouchEvent): void {
-    // Only track single-finger touches; pinch/zoom (2+ fingers) are ignored
-    if (e.touches.length !== 1) {
+    // Only track two-finger touches for tab switching
+    if (e.touches.length !== 2) {
       this._touchActive = false;
       return;
     }
@@ -350,7 +350,7 @@ export class App implements OnInit, OnDestroy {
   }
 
   private onTouchMove(e: TouchEvent): void {
-    if (!this._touchActive || e.touches.length !== 1) return;
+    if (!this._touchActive || e.touches.length !== 2) return;
     this._touchLastX = e.touches[0].clientX;
     this._touchLastY = e.touches[0].clientY;
   }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -199,10 +199,6 @@ import { MatDialogRef } from '@angular/material/dialog';
           </div>
         }
         <div class="main-content u-flex-col" #content>
-          <span class="main-corner main-corner--tl">◆</span>
-          <span class="main-corner main-corner--tr">◆</span>
-          <span class="main-corner main-corner--bl">◆</span>
-          <span class="main-corner main-corner--br">◆</span>
           <router-outlet />
         </div>
         @if (showBackToTop()) {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -29,10 +29,7 @@ import { MatDialogRef } from '@angular/material/dialog';
   },
   template: `
     <mat-sidenav-container class="container">
-      <mat-sidenav #sidenav mode="over" class="sidenav"
-        (opened)="sidenavOpen.set(true)"
-        (closed)="sidenavOpen.set(false)">
-
+      <mat-sidenav #sidenav mode="over" class="sidenav" (opened)="sidenavOpen.set(true)" (closed)="sidenavOpen.set(false)">
         <!-- logo -->
         <div class="sidenav__logo-wrap">
           <img src="JaD-logo.png" alt="Jeskyně a Draci" class="sidenav__logo" />
@@ -51,14 +48,14 @@ import { MatDialogRef } from '@angular/material/dialog';
             <span class="sidenav__link-label">Karta postavy</span>
             <span class="sidenav__link-arrow">›</span>
           </a>
-          <a [routerLink]="routes.dmScreen" class="sidenav__link" (click)="sidenav.toggle()">
-            <span class="sidenav__link-icon"><mat-icon>full_coverage</mat-icon></span>
-            <span class="sidenav__link-label">PH zástěna</span>
-            <span class="sidenav__link-arrow">›</span>
-          </a>
           <a [routerLink]="routes.dmPage" class="sidenav__link" (click)="sidenav.toggle()">
             <span class="sidenav__link-icon"><mat-icon>construction</mat-icon></span>
             <span class="sidenav__link-label">PH nástroje</span>
+            <span class="sidenav__link-arrow">›</span>
+          </a>
+          <a [routerLink]="routes.dmScreen" class="sidenav__link" (click)="sidenav.toggle()">
+            <span class="sidenav__link-icon"><mat-icon>full_coverage</mat-icon></span>
+            <span class="sidenav__link-label">PH zástěna</span>
             <span class="sidenav__link-arrow">›</span>
           </a>
           <a [routerLink]="routes.dndDatabase" class="sidenav__link" (click)="sidenav.toggle()">
@@ -77,24 +74,24 @@ import { MatDialogRef } from '@angular/material/dialog';
             <span class="sidenav__link-arrow">›</span>
           </a>
         </nav>
-
       </mat-sidenav>
 
       <mat-sidenav-content #sidenavContent>
         <mat-toolbar class="toolbar">
           <div class="toolbar__inner">
             <div class="toolbar__left u-flex u-align-center">
-              <button matIconButton (click)="sidenav.toggle()" class="menu-btn u-mr-3" aria-label="Otevřít menu" matTooltip="Navigace">
+              <button
+                matIconButton
+                (click)="sidenav.toggle()"
+                class="menu-btn u-mr-3"
+                aria-label="Otevřít menu"
+                matTooltip="Navigace"
+              >
                 <mat-icon>menu</mat-icon>
               </button>
               <img src="JaD-logo.png" alt="Dungeons & Dragons Logo" class="logo u-mr-3" />
               <span class="toolbar-servant-text">Servant</span>
-              <button
-                type="button"
-                class="github-link settings-btn u-ml-2"
-                (click)="openSettings()"
-                matTooltip="Nastavení"
-              >
+              <button type="button" class="github-link settings-btn u-ml-2" (click)="openSettings()" matTooltip="Nastavení">
                 <mat-icon class="toolbar-icon">settings</mat-icon>
               </button>
               <button
@@ -127,10 +124,11 @@ import { MatDialogRef } from '@angular/material/dialog';
             </div>
             <div class="toolbar__right author-info u-flex u-align-center">
               @if (authService.currentUser()) {
-              <b class="username u-mr-2">{{ authService.currentUser()!.username }}</b>
-              <a class="link token u-mr-2" href="#" (click)="$event.preventDefault(); logout()">Odhlásit</a>
-              } @if (authService.currentUser() === null) {
-              <a class="link token u-mr-2" [routerLink]="routes.login">Přihlásit</a>
+                <b class="username u-mr-2">{{ authService.currentUser()!.username }}</b>
+                <a class="link token u-mr-2" href="#" (click)="$event.preventDefault(); logout()">Odhlásit</a>
+              }
+              @if (authService.currentUser() === null) {
+                <a class="link token u-mr-2" [routerLink]="routes.login">Přihlásit</a>
               }
               <a
                 target="_blank"
@@ -156,30 +154,49 @@ import { MatDialogRef } from '@angular/material/dialog';
         </mat-toolbar>
         <!-- Mobile account dropdown -->
         @if (mobileMenuOpen()) {
-        <div class="mobile-menu-backdrop" (click)="mobileMenuOpen.set(false)"></div>
-        <div class="mobile-menu-dropdown">
-          <div class="mobile-menu-section">
-            @if (authService.currentUser()) {
-            <b class="mobile-menu-username">{{ authService.currentUser()!.username }}</b>
-            <a class="link token mobile-menu-link" href="#" (click)="$event.preventDefault(); logout(); mobileMenuOpen.set(false)">
-              <mat-icon class="mobile-menu-icon">logout</mat-icon> Odhlásit
-            </a>
-            } @if (authService.currentUser() === null) {
-            <a class="link token mobile-menu-link" [routerLink]="routes.login" (click)="mobileMenuOpen.set(false)">
-              <mat-icon class="mobile-menu-icon">login</mat-icon> Přihlásit
-            </a>
-            }
+          <div class="mobile-menu-backdrop" (click)="mobileMenuOpen.set(false)"></div>
+          <div class="mobile-menu-dropdown">
+            <div class="mobile-menu-section">
+              @if (authService.currentUser()) {
+                <b class="mobile-menu-username">{{ authService.currentUser()!.username }}</b>
+                <a
+                  class="link token mobile-menu-link"
+                  href="#"
+                  (click)="$event.preventDefault(); logout(); mobileMenuOpen.set(false)"
+                >
+                  <mat-icon class="mobile-menu-icon">logout</mat-icon>
+                  Odhlásit
+                </a>
+              }
+              @if (authService.currentUser() === null) {
+                <a class="link token mobile-menu-link" [routerLink]="routes.login" (click)="mobileMenuOpen.set(false)">
+                  <mat-icon class="mobile-menu-icon">login</mat-icon>
+                  Přihlásit
+                </a>
+              }
+            </div>
+            <div class="mobile-menu-divider"></div>
+            <div class="mobile-menu-section">
+              <a
+                target="_blank"
+                href="https://github.com/Evincars/DnD-Servant"
+                class="mobile-menu-link token"
+                (click)="mobileMenuOpen.set(false)"
+              >
+                <mat-icon class="mobile-menu-icon">code_blocks</mat-icon>
+                GitHub
+              </a>
+              <a
+                class="mobile-menu-link token"
+                target="_blank"
+                href="https://lasak.netlify.app/"
+                (click)="mobileMenuOpen.set(false)"
+              >
+                <mat-icon class="mobile-menu-icon">language</mat-icon>
+                lasaks.eu
+              </a>
+            </div>
           </div>
-          <div class="mobile-menu-divider"></div>
-          <div class="mobile-menu-section">
-            <a target="_blank" href="https://github.com/Evincars/DnD-Servant" class="mobile-menu-link token" (click)="mobileMenuOpen.set(false)">
-              <mat-icon class="mobile-menu-icon">code_blocks</mat-icon> GitHub
-            </a>
-            <a class="mobile-menu-link token" target="_blank" href="https://lasak.netlify.app/" (click)="mobileMenuOpen.set(false)">
-              <mat-icon class="mobile-menu-icon">language</mat-icon> lasaks.eu
-            </a>
-          </div>
-        </div>
         }
         <div class="main-content u-flex-col" #content>
           <span class="main-corner main-corner--tl">◆</span>
@@ -189,16 +206,16 @@ import { MatDialogRef } from '@angular/material/dialog';
           <router-outlet />
         </div>
         @if (showBackToTop()) {
-        <button
-          (click)="scrollToTop()"
-          mat-fab
-          class="back-to-top"
-          matTooltip="Scroll zpátky nahoru"
-          color="secondary"
-          aria-label="Back to top"
-        >
-          <mat-icon>arrow_upward</mat-icon>
-        </button>
+          <button
+            (click)="scrollToTop()"
+            mat-fab
+            class="back-to-top"
+            matTooltip="Scroll zpátky nahoru"
+            color="secondary"
+            aria-label="Back to top"
+          >
+            <mat-icon>arrow_upward</mat-icon>
+          </button>
         }
       </mat-sidenav-content>
     </mat-sidenav-container>
@@ -392,8 +409,12 @@ export class App implements OnInit, OnDestroy {
   }
 
   // ── Sidenav open/close — hide dice-roller tab via body class ────
-  onSidenavOpened(): void { this.doc.body.classList.add('sidenav-open'); }
-  onSidenavClosed(): void { this.doc.body.classList.remove('sidenav-open'); }
+  onSidenavOpened(): void {
+    this.doc.body.classList.add('sidenav-open');
+  }
+  onSidenavClosed(): void {
+    this.doc.body.classList.remove('sidenav-open');
+  }
 
   // ── Scroll handler ───────────────────────────────────────
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -29,7 +29,9 @@ import { MatDialogRef } from '@angular/material/dialog';
   },
   template: `
     <mat-sidenav-container class="container">
-      <mat-sidenav #sidenav mode="over" class="sidenav">
+      <mat-sidenav #sidenav mode="over" class="sidenav"
+        (opened)="sidenavOpen.set(true)"
+        (closed)="sidenavOpen.set(false)">
 
         <!-- logo -->
         <div class="sidenav__logo-wrap">
@@ -233,6 +235,7 @@ export class App implements OnInit, OnDestroy {
   showBackToTop = signal(false);
   screenshotLoading = signal(false);
   mobileMenuOpen = signal(false);
+  sidenavOpen = signal(false);
   private firstLoad = true;
 
   // ── Single-finger horizontal swipe tracking ──────────────
@@ -387,6 +390,10 @@ export class App implements OnInit, OnDestroy {
       hasBackdrop: true,
     });
   }
+
+  // ── Sidenav open/close — hide dice-roller tab via body class ────
+  onSidenavOpened(): void { this.doc.body.classList.add('sidenav-open'); }
+  onSidenavClosed(): void { this.doc.body.classList.remove('sidenav-open'); }
 
   // ── Scroll handler ───────────────────────────────────────
 

--- a/src/app/command-palette.component.ts
+++ b/src/app/command-palette.component.ts
@@ -295,9 +295,8 @@ const APP_COMMANDS: CommandItem[] = [
     .cp-panel {
       background: linear-gradient(180deg, rgba(14,11,9,.97) 0%, rgba(22,17,13,.98) 100%);
       border: 1px solid rgba(200,160,60,.4);
-      border-radius: 12px;
       overflow: hidden;
-      width: min(580px, 96vw);
+      width: 100%;
       display: flex;
       flex-direction: column;
       height: auto;

--- a/src/app/command-palette.component.ts
+++ b/src/app/command-palette.component.ts
@@ -302,17 +302,8 @@ const APP_COMMANDS: CommandItem[] = [
       flex-direction: column;
 
       &::before {
-        content: '◆';
-        position: absolute;
-        top: -7px;
-        left: 50%;
-        transform: translateX(-50%);
-        font-size: 9px;
-        color: rgba(200,160,60,.6);
-        background: rgba(8,5,16,1);
-        padding: 0 6px;
-        pointer-events: none;
-        z-index: 2;
+        content: '';
+        display: none;
       }
     }
 

--- a/src/app/command-palette.component.ts
+++ b/src/app/command-palette.component.ts
@@ -293,13 +293,15 @@ const APP_COMMANDS: CommandItem[] = [
   `,
   styles: `
     .cp-panel {
-      background: linear-gradient(180deg, rgba(8,5,16,.99) 0%, rgba(14,10,22,.99) 100%);
+      background: linear-gradient(180deg, rgba(14,11,9,.97) 0%, rgba(22,17,13,.98) 100%);
       border: 1px solid rgba(200,160,60,.4);
       border-radius: 12px;
       overflow: hidden;
       width: min(580px, 96vw);
       display: flex;
       flex-direction: column;
+      height: auto;
+      opacity: 0.8;
 
       &::before {
         content: '';

--- a/src/app/donate-dialog.component.ts
+++ b/src/app/donate-dialog.component.ts
@@ -44,18 +44,6 @@ import { MatIcon } from '@angular/material/icon';
       flex-direction: column;
       position: relative;
 
-      &::before {
-        content: '◆';
-        position: absolute;
-        top: -7px; left: 50%;
-        transform: translateX(-50%);
-        font-size: 9px;
-        color: rgba(200,160,60,.6);
-        background: rgba(8,5,18,1);
-        padding: 0 6px;
-        pointer-events: none;
-        z-index: 2;
-      }
     }
 
     /* ── Header ────────────────────────────────────────────── */

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -19,8 +19,9 @@ const RELEASE_NOTES: ReleaseGroup[] = [
   {
     date: '5. července 2026',
     entries: [
-      i('Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy'),
-      i('Lepší, jednodušší design tabů (změna pořadí stránek + Konvertor Obrázků přesunut na PH Nástroje), odstranění zbytečných nadpisů z daných stránek, změna barevné palety atp.')
+      i('Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy.'),
+      i('Lepší, jednodušší design tabů (změna pořadí stránek + Konvertor Obrázků přesunut na PH Nástroje), odstranění zbytečných nadpisů z daných stránek, změna barevné palety pro některé prvky.'),
+      i('DM Qeusty a hráčské Questy - vylepšený a zjednodušený design karet, vč. odstranění obrázku.'),
     ],
   },
   {

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -17,7 +17,7 @@ const f = (text: string): ReleaseEntry => ({ type: 'fix', text });
 
 const RELEASE_NOTES: ReleaseGroup[] = [
   {
-    date: '5. července 2026',
+    date: '10. července 2026',
     entries: [
       i(
         'Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy.',

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -21,8 +21,9 @@ const RELEASE_NOTES: ReleaseGroup[] = [
     entries: [
       i('Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy.'),
       i('Lepší, jednodušší design tabů (změna pořadí stránek + Konvertor Obrázků přesunut na PH Nástroje), odstranění zbytečných nadpisů z daných stránek, změna barevné palety pro některé prvky.'),
-      i('DM Qeusty a hráčské Questy - vylepšený a zjednodušený design karet, vč. odstranění obrázku.'),
-      i('Tabulka Iniciativy - zjednodušený design.'),
+      i('DM Qeusty a hráčské Questy - vylepšený a zjednodušený design karet, odstranění obrázku, uložení vybraného filtru'),
+      i('Tabulka Iniciativy - zjednodušený a vylepšený design (vč. karet příšer pro DM).'),
+      i(''),
     ],
   },
   {

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -305,16 +305,8 @@ const TYPE_LABELS: Record<ReleaseEntry['type'], string> = {
       max-height: 82vh;
 
       &::before {
-        content: '◆';
-        position: absolute;
-        top: -7px; left: 50%;
-        transform: translateX(-50%);
-        font-size: 9px;
-        color: rgba(200,160,60,.6);
-        background: rgba(8,5,18,1);
-        padding: 0 6px;
-        pointer-events: none;
-        z-index: 2;
+        content: '';
+        display: none;
       }
     }
 

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -22,6 +22,7 @@ const RELEASE_NOTES: ReleaseGroup[] = [
       i('Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy.'),
       i('Lepší, jednodušší design tabů (změna pořadí stránek + Konvertor Obrázků přesunut na PH Nástroje), odstranění zbytečných nadpisů z daných stránek, změna barevné palety pro některé prvky.'),
       i('DM Qeusty a hráčské Questy - vylepšený a zjednodušený design karet, vč. odstranění obrázku.'),
+      i('Tabulka Iniciativy - zjednodušený design.'),
     ],
   },
   {

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -20,7 +20,7 @@ const RELEASE_NOTES: ReleaseGroup[] = [
     date: '5. července 2026',
     entries: [
       i('Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy'),
-      i('Lepší, jednodušší design tabů, odstranění zbytečných nadpisů z daných stránek, změna barevné palety atp.')
+      i('Lepší, jednodušší design tabů (změna pořadí stránek + Konvertor Obrázků přesunut na PH Nástroje), odstranění zbytečných nadpisů z daných stránek, změna barevné palety atp.')
     ],
   },
   {

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -17,6 +17,12 @@ const f = (text: string): ReleaseEntry => ({ type: 'fix', text });
 
 const RELEASE_NOTES: ReleaseGroup[] = [
   {
+    date: '5. července 2026',
+    entries: [
+      i('Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy'),
+    ],
+  },
+  {
     date: '25. června 2026',
     entries: [
       f('Login pomocí Google účtu, staré přihlašování je povolené, ale nově příchozí musí použít Google'),

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -20,6 +20,7 @@ const RELEASE_NOTES: ReleaseGroup[] = [
     date: '5. července 2026',
     entries: [
       i('Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy'),
+      i('Lepší, jednodušší design tabů, odstranění zbytečných nadpisů z daných stránek, změna barevné palety atp.')
     ],
   },
   {

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -23,7 +23,6 @@ const RELEASE_NOTES: ReleaseGroup[] = [
       i('Lepší, jednodušší design tabů (změna pořadí stránek + Konvertor Obrázků přesunut na PH Nástroje), odstranění zbytečných nadpisů z daných stránek, změna barevné palety pro některé prvky.'),
       i('DM Qeusty a hráčské Questy - vylepšený a zjednodušený design karet, odstranění obrázku, uložení vybraného filtru'),
       i('Tabulka Iniciativy - zjednodušený a vylepšený design (vč. karet příšer pro DM).'),
-      i(''),
     ],
   },
   {

--- a/src/app/release-notes-dialog.component.ts
+++ b/src/app/release-notes-dialog.component.ts
@@ -19,10 +19,18 @@ const RELEASE_NOTES: ReleaseGroup[] = [
   {
     date: '5. července 2026',
     entries: [
-      i('Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy.'),
-      i('Lepší, jednodušší design tabů (změna pořadí stránek + Konvertor Obrázků přesunut na PH Nástroje), odstranění zbytečných nadpisů z daných stránek, změna barevné palety pro některé prvky.'),
+      i(
+        'Vylepšená J&D wiki - lepší vyhledávání, scroll na pozici i pro podkapitoly, přizpůsobení mobilům a tabletům, zlepšení výkonu při dlouhých textech, Obsah Kapitoly s vyhledáváním, opraveny linky pro nadpisy.',
+      ),
+      i(
+        'Lepší, jednodušší design tabů (změna pořadí stránek + Konvertor Obrázků přesunut na PH Nástroje), odstranění zbytečných nadpisů z daných stránek, změna barevné palety pro některé prvky.',
+      ),
       i('DM Qeusty a hráčské Questy - vylepšený a zjednodušený design karet, odstranění obrázku, uložení vybraného filtru'),
       i('Tabulka Iniciativy - zjednodušený a vylepšený design (vč. karet příšer pro DM).'),
+      i(
+        'Příběhové události - zjednodušený a vylepšený design. Přidání možnosti sdílení s ostatními hráči (ostatní nemůžou zapisovat do sdílených událostí, jen autor). Hráč může vidět sdílené události a zároveň vytvořit svoje vlastní a sdílet je dál.',
+      ),
+      i('Ctrl+S - klávesová zkratka pro ukládání - funguje všude'),
     ],
   },
   {

--- a/src/app/settings-dialog.component.ts
+++ b/src/app/settings-dialog.component.ts
@@ -30,198 +30,197 @@ export interface SettingsDialogData {
 
       <!-- Body -->
       <div class="sd-body">
-
         <!-- LEFT column -->
         <div class="sd-col-panel">
+          <!-- Theme section -->
+          <div class="sd-section u-mb-6">
+            <div class="sd-section-label">Téma karet</div>
+            <div class="sd-theme-grid">
+              <button
+                type="button"
+                class="sd-btn sd-btn--theme"
+                [class.sd-btn--active]="sheetTheme.theme() === 'light'"
+                (click)="sheetTheme.setTheme('light')"
+              >
+                <mat-icon class="sd-btn-icon sd-icon--light">light_mode</mat-icon>
+                <span class="sd-btn-label">Světlé</span>
+              </button>
+              <button
+                type="button"
+                class="sd-btn sd-btn--theme"
+                [class.sd-btn--active]="sheetTheme.theme() === 'dark'"
+                (click)="sheetTheme.setTheme('dark')"
+              >
+                <mat-icon class="sd-btn-icon sd-icon--dark">dark_mode</mat-icon>
+                <span class="sd-btn-label">Tmavé</span>
+              </button>
+              <button
+                type="button"
+                class="sd-btn sd-btn--theme"
+                [class.sd-btn--active]="sheetTheme.theme() === 'sirien'"
+                (click)="sheetTheme.setTheme('sirien')"
+              >
+                <mat-icon class="sd-btn-icon sd-icon--sirien">auto_awesome</mat-icon>
+                <span class="sd-btn-label">Sirien</span>
+              </button>
+              <button
+                type="button"
+                class="sd-btn sd-btn--theme"
+                [class.sd-btn--active]="sheetTheme.theme() === 'night'"
+                (click)="sheetTheme.setTheme('night')"
+              >
+                <mat-icon class="sd-btn-icon sd-icon--night">nights_stay</mat-icon>
+                <span class="sd-btn-label">Noční</span>
+              </button>
+            </div>
+          </div>
 
-        <!-- Theme section -->
-        <div class="sd-section u-mb-6">
-          <div class="sd-section-label">Téma karet</div>
-          <div class="sd-theme-grid">
-            <button
-              type="button"
-              class="sd-btn sd-btn--theme"
-              [class.sd-btn--active]="sheetTheme.theme() === 'light'"
-              (click)="sheetTheme.setTheme('light')"
-            >
-              <mat-icon class="sd-btn-icon sd-icon--light">light_mode</mat-icon>
-              <span class="sd-btn-label">Světlé</span>
-            </button>
-            <button
-              type="button"
-              class="sd-btn sd-btn--theme"
-              [class.sd-btn--active]="sheetTheme.theme() === 'dark'"
-              (click)="sheetTheme.setTheme('dark')"
-            >
-              <mat-icon class="sd-btn-icon sd-icon--dark">dark_mode</mat-icon>
-              <span class="sd-btn-label">Tmavé</span>
-            </button>
-            <button
-              type="button"
-              class="sd-btn sd-btn--theme"
-              [class.sd-btn--active]="sheetTheme.theme() === 'sirien'"
-              (click)="sheetTheme.setTheme('sirien')"
-            >
-              <mat-icon class="sd-btn-icon sd-icon--sirien">auto_awesome</mat-icon>
-              <span class="sd-btn-label">Sirien</span>
-            </button>
-            <button
-              type="button"
-              class="sd-btn sd-btn--theme"
-              [class.sd-btn--active]="sheetTheme.theme() === 'night'"
-              (click)="sheetTheme.setTheme('night')"
-            >
-              <mat-icon class="sd-btn-icon sd-icon--night">nights_stay</mat-icon>
-              <span class="sd-btn-label">Noční</span>
-            </button>
+          <!--        <div class="sd-divider"></div>-->
+
+          <!-- Page layout section -->
+          <div class="sd-section">
+            <div class="sd-section-label">Rozvržení stránek</div>
+            <div class="sd-col">
+              <button
+                type="button"
+                class="sd-btn sd-btn--wide"
+                [class.sd-btn--active]="!sheetTheme.spellsFirst()"
+                (click)="sheetTheme.spellsFirst() && sheetTheme.toggleSpellsFirst()"
+              >
+                <!--              <mat-icon class="sd-btn-icon">format_list_numbered</mat-icon>-->
+                <div class="sd-btn-text">
+                  <span class="sd-btn-label">Výchozí pořadí</span>
+                  <span class="sd-btn-sub">Str. 2 – Vzhled &amp; popis · str. 3 – Kouzla</span>
+                </div>
+              </button>
+              <button
+                type="button"
+                class="sd-btn sd-btn--wide"
+                [class.sd-btn--active]="sheetTheme.spellsFirst()"
+                (click)="!sheetTheme.spellsFirst() && sheetTheme.toggleSpellsFirst()"
+              >
+                <!--              <mat-icon class="sd-btn-icon">auto_fix_high</mat-icon>-->
+                <div class="sd-btn-text">
+                  <span class="sd-btn-label">Kouzla napřed</span>
+                  <span class="sd-btn-sub">Str. 2 – Kouzla · str. 3 – Vzhled &amp; popis</span>
+                </div>
+              </button>
+            </div>
           </div>
         </div>
-
-<!--        <div class="sd-divider"></div>-->
-
-        <!-- Page layout section -->
-        <div class="sd-section">
-          <div class="sd-section-label">Rozvržení stránek</div>
-          <div class="sd-col">
-            <button
-              type="button"
-              class="sd-btn sd-btn--wide"
-              [class.sd-btn--active]="!sheetTheme.spellsFirst()"
-              (click)="sheetTheme.spellsFirst() && sheetTheme.toggleSpellsFirst()"
-            >
-<!--              <mat-icon class="sd-btn-icon">format_list_numbered</mat-icon>-->
-              <div class="sd-btn-text">
-                <span class="sd-btn-label">Výchozí pořadí</span>
-                <span class="sd-btn-sub">Str. 2 – Vzhled &amp; popis · str. 3 – Kouzla</span>
-              </div>
-            </button>
-            <button
-              type="button"
-              class="sd-btn sd-btn--wide"
-              [class.sd-btn--active]="sheetTheme.spellsFirst()"
-              (click)="!sheetTheme.spellsFirst() && sheetTheme.toggleSpellsFirst()"
-            >
-<!--              <mat-icon class="sd-btn-icon">auto_fix_high</mat-icon>-->
-              <div class="sd-btn-text">
-                <span class="sd-btn-label">Kouzla napřed</span>
-                <span class="sd-btn-sub">Str. 2 – Kouzla · str. 3 – Vzhled &amp; popis</span>
-              </div>
-            </button>
-          </div>
-        </div>
-
-        </div><!-- /sd-col-panel LEFT -->
+        <!-- /sd-col-panel LEFT -->
 
         <!-- vertical separator -->
         <div class="sd-col-sep"></div>
 
         <!-- RIGHT column -->
         <div class="sd-col-panel">
-
-        <!-- Export section -->
-        <div class="sd-section u-mb-6">
-          <div class="sd-section-label">Záloha &amp; export <span style="color: red;">(experimentální)</span></div>
-          <div class="sd-col">
-            <button
-              type="button"
-              class="sd-btn sd-btn--wide"
-              [disabled]="data.screenshotLoading()"
-              (click)="screenshotClick.emit()"
-            >
-              <mat-icon class="sd-btn-icon">
-                {{ data.screenshotLoading() ? 'hourglass_empty' : 'photo_camera' }}
-              </mat-icon>
-              <div class="sd-btn-text">
-                <span class="sd-btn-label">Záloha jako obrázek (PNG)</span>
-                <span class="sd-btn-sub">Stáhne aktuální kartu jako PNG soubor</span>
-              </div>
-            </button>
-            <button
-              type="button"
-              class="sd-btn sd-btn--wide"
-              (click)="jsonClick.emit()"
-            >
-              <mat-icon class="sd-btn-icon">download</mat-icon>
-              <div class="sd-btn-text">
-                <span class="sd-btn-label">Záloha jako JSON</span>
-                <span class="sd-btn-sub">Exportuje databázi do JSON souboru</span>
-              </div>
-            </button>
-          </div>
-        </div>
-
-<!--        <div class="sd-divider"></div>-->
-
-        <!-- Keyboard shortcuts section -->
-        <div class="sd-section u-mb-6">
-          <div class="sd-section-label">Klávesové zkratky &amp; gesta</div>
-          <div class="sd-col">
-            <div class="sd-shortcut-row">
-              <div class="sd-shortcut-keys">
-                <kbd>Alt</kbd><span class="sd-shortcut-sep">+</span><kbd>←</kbd>
-                <span class="sd-shortcut-slash">/</span>
-                <kbd>Alt</kbd><span class="sd-shortcut-sep">+</span><kbd>→</kbd>
-              </div>
-              <span class="sd-shortcut-desc">Přepínání záložek</span>
+          <!-- Export section -->
+          <div class="sd-section u-mb-6">
+            <div class="sd-section-label">
+              Záloha &amp; export
+              <span style="color: red;">(experimentální)</span>
             </div>
-            <div class="sd-shortcut-row">
-              <div class="sd-shortcut-keys">
-                <kbd>Ctrl</kbd><span class="sd-shortcut-sep">+</span><kbd>K</kbd>
-              </div>
-              <span class="sd-shortcut-desc">Rychlá navigace (příkazová paleta)</span>
-            </div>
-            <div class="sd-shortcut-row">
-              <div class="sd-shortcut-keys sd-shortcut-keys--gesture">
-                <span class="sd-gesture-swipe">swipe 2 prsty doprava/doleva</span>
-<!--                <span class="sd-shortcut-slash">/</span>-->
-<!--                <span class="sd-gesture-swipe">2× swipe →</span>-->
-              </div>
-              <span class="sd-shortcut-desc">Přepínání záložek</span>
-            </div>
-          </div>
-        </div>
-
-<!--        <div class="sd-divider"></div>-->
-
-        <!-- Credits section -->
-        <div class="sd-section">
-          <div class="sd-section-label">Poděkování</div>
-          <div class="sd-col">
-<!--            <div class="sd-credits-row">-->
-<!--              <mat-icon class="sd-credits-icon">auto_awesome</mat-icon>-->
-<!--              <span class="sd-credits-text">-->
-<!--                Speciální poděkování-->
-<!--                <span class="sd-credit-name">&#64;Sirien</span>-->
-<!--                a-->
-<!--                <span class="sd-credit-name">&#64;Dukolm</span>-->
-<!--                za jejich příspěvky a podporu projektu. A spoustě dalších z J&D komunity.-->
-<!--              </span>-->
-<!--            </div>-->
-            <div class="sd-credits-links">
-              <a
-                href="https://www.jeskyneadraci.cz/"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="sd-credits-link"
+            <div class="sd-col">
+              <button
+                type="button"
+                class="sd-btn sd-btn--wide"
+                [disabled]="data.screenshotLoading()"
+                (click)="screenshotClick.emit()"
               >
-                <mat-icon class="sd-credits-link-icon">menu_book</mat-icon>
-                <span>Jeskyně a Draci</span>
-              </a>
-              <a
-                href="https://discord.com/invite/5uVhJh2"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="sd-credits-link"
-              >
-                <mat-icon class="sd-credits-link-icon">forum</mat-icon>
-                <span>Discord Mytago</span>
-              </a>
+                <mat-icon class="sd-btn-icon">
+                  {{ data.screenshotLoading() ? 'hourglass_empty' : 'photo_camera' }}
+                </mat-icon>
+                <div class="sd-btn-text">
+                  <span class="sd-btn-label">Záloha jako obrázek (PNG)</span>
+                  <span class="sd-btn-sub">Stáhne aktuální kartu jako PNG soubor</span>
+                </div>
+              </button>
+              <button type="button" class="sd-btn sd-btn--wide" (click)="jsonClick.emit()">
+                <mat-icon class="sd-btn-icon">download</mat-icon>
+                <div class="sd-btn-text">
+                  <span class="sd-btn-label">Záloha jako JSON</span>
+                  <span class="sd-btn-sub">Exportuje databázi do JSON souboru</span>
+                </div>
+              </button>
+            </div>
+          </div>
+
+          <!--        <div class="sd-divider"></div>-->
+
+          <!-- Keyboard shortcuts section -->
+          <div class="sd-section u-mb-6">
+            <div class="sd-section-label">Klávesové zkratky &amp; gesta</div>
+            <div class="sd-col">
+              <div class="sd-shortcut-row">
+                <div class="sd-shortcut-keys">
+                  <kbd>Alt</kbd>
+                  <span class="sd-shortcut-sep">+</span>
+                  <kbd>←</kbd>
+                  <span class="sd-shortcut-slash">/</span>
+                  <kbd>Alt</kbd>
+                  <span class="sd-shortcut-sep">+</span>
+                  <kbd>→</kbd>
+                </div>
+                <span class="sd-shortcut-desc">Přepínání záložek</span>
+              </div>
+              <div class="sd-shortcut-row">
+                <div class="sd-shortcut-keys">
+                  <kbd>Ctrl</kbd>
+                  <span class="sd-shortcut-sep">+</span>
+                  <kbd>K</kbd>
+                </div>
+                <span class="sd-shortcut-desc">Rychlá navigace (příkazová paleta)</span>
+              </div>
+              <div class="sd-shortcut-row">
+                <div class="sd-shortcut-keys">
+                  <kbd>Ctrl</kbd>
+                  <span class="sd-shortcut-sep">+</span>
+                  <kbd>S</kbd>
+                </div>
+                <span class="sd-shortcut-desc">Uložit</span>
+              </div>
+              <div class="sd-shortcut-row">
+                <div class="sd-shortcut-keys sd-shortcut-keys--gesture">
+                  <span class="sd-gesture-swipe">swipe 2 prsty doprava/doleva</span>
+                  <!--                <span class="sd-shortcut-slash">/</span>-->
+                  <!--                <span class="sd-gesture-swipe">2× swipe →</span>-->
+                </div>
+                <span class="sd-shortcut-desc">Přepínání záložek</span>
+              </div>
+            </div>
+          </div>
+
+          <!--        <div class="sd-divider"></div>-->
+
+          <!-- Credits section -->
+          <div class="sd-section">
+            <div class="sd-section-label">Poděkování</div>
+            <div class="sd-col">
+              <!--            <div class="sd-credits-row">-->
+              <!--              <mat-icon class="sd-credits-icon">auto_awesome</mat-icon>-->
+              <!--              <span class="sd-credits-text">-->
+              <!--                Speciální poděkování-->
+              <!--                <span class="sd-credit-name">&#64;Sirien</span>-->
+              <!--                a-->
+              <!--                <span class="sd-credit-name">&#64;Dukolm</span>-->
+              <!--                za jejich příspěvky a podporu projektu. A spoustě dalších z J&D komunity.-->
+              <!--              </span>-->
+              <!--            </div>-->
+              <div class="sd-credits-links">
+                <a href="https://www.jeskyneadraci.cz/" target="_blank" rel="noopener noreferrer" class="sd-credits-link">
+                  <mat-icon class="sd-credits-link-icon">menu_book</mat-icon>
+                  <span>Jeskyně a Draci</span>
+                </a>
+                <a href="https://discord.com/invite/5uVhJh2" target="_blank" rel="noopener noreferrer" class="sd-credits-link">
+                  <mat-icon class="sd-credits-link-icon">forum</mat-icon>
+                  <span>Discord Mytago</span>
+                </a>
+              </div>
             </div>
           </div>
         </div>
-
-        </div><!-- /sd-col-panel RIGHT -->
-
+        <!-- /sd-col-panel RIGHT -->
       </div>
 
       <!-- Version footer -->
@@ -234,9 +233,8 @@ export interface SettingsDialogData {
   styles: `
     /* ── Panel ─────────────────────────────────────────────── */
     .sd-panel {
-      background:
-        linear-gradient(180deg, rgba(14,11,9,.98) 0%, rgba(22,17,13,.99) 100%);
-      border: 1px solid rgba(200,160,60,.4);
+      background: linear-gradient(180deg, rgba(14, 11, 9, 0.98) 0%, rgba(22, 17, 13, 0.99) 100%);
+      border: 1px solid rgba(200, 160, 60, 0.4);
       border-radius: 10px;
       overflow: hidden;
       min-width: 320px;
@@ -258,15 +256,15 @@ export interface SettingsDialogData {
       align-items: center;
       gap: 10px;
       padding: 14px 16px 12px;
-      border-bottom: 1px solid rgba(200,160,60,.18);
-      background: rgba(200,160,60,.04);
+      border-bottom: 1px solid rgba(200, 160, 60, 0.18);
+      background: rgba(200, 160, 60, 0.04);
     }
 
     .sd-header-icon {
       font-size: 18px;
       width: 18px;
       height: 18px;
-      color: rgba(200,160,60,.7);
+      color: rgba(200, 160, 60, 0.7);
       flex-shrink: 0;
     }
 
@@ -274,10 +272,10 @@ export interface SettingsDialogData {
       flex: 1;
       font-family: sans-serif;
       font-size: 14px;
-      letter-spacing: .1em;
+      letter-spacing: 0.1em;
       text-transform: uppercase;
       color: #e8c96a;
-      text-shadow: 0 0 12px rgba(200,160,60,.4);
+      text-shadow: 0 0 12px rgba(200, 160, 60, 0.4);
     }
 
     .sd-close-btn {
@@ -290,14 +288,20 @@ export interface SettingsDialogData {
       background: transparent;
       cursor: pointer;
       border-radius: 4px;
-      color: rgba(200,160,60,.45);
-      transition: color .15s, background .15s;
+      color: rgba(200, 160, 60, 0.45);
+      transition:
+        color 0.15s,
+        background 0.15s;
 
-      mat-icon { font-size: 18px; width: 18px; height: 18px; }
+      mat-icon {
+        font-size: 18px;
+        width: 18px;
+        height: 18px;
+      }
 
       &:hover {
-        background: rgba(200,160,60,.1);
-        color: rgba(200,160,60,.9);
+        background: rgba(200, 160, 60, 0.1);
+        color: rgba(200, 160, 60, 0.9);
       }
     }
 
@@ -325,7 +329,7 @@ export interface SettingsDialogData {
       width: 1px;
       align-self: stretch;
       margin: 0 20px;
-      background: linear-gradient(180deg, transparent, rgba(200,160,60,.25), transparent);
+      background: linear-gradient(180deg, transparent, rgba(200, 160, 60, 0.25), transparent);
     }
 
     .sd-section {
@@ -337,14 +341,14 @@ export interface SettingsDialogData {
     .sd-section-label {
       font-family: sans-serif;
       font-size: 10px;
-      letter-spacing: .15em;
+      letter-spacing: 0.15em;
       text-transform: uppercase;
-      color: rgba(200,160,60,.5);
+      color: rgba(200, 160, 60, 0.5);
     }
 
     .sd-divider {
       height: 1px;
-      background: linear-gradient(90deg, transparent, rgba(200,160,60,.25), transparent);
+      background: linear-gradient(90deg, transparent, rgba(200, 160, 60, 0.25), transparent);
       margin: 16px 0;
     }
 
@@ -373,28 +377,35 @@ export interface SettingsDialogData {
       align-items: center;
       gap: 10px;
       padding: 10px 14px;
-      border: 1px solid rgba(200,160,60,.22);
+      border: 1px solid rgba(200, 160, 60, 0.22);
       border-radius: 7px;
-      background: rgba(200,160,60,.06);
+      background: rgba(200, 160, 60, 0.06);
       cursor: pointer;
-      transition: background .15s, border-color .15s, box-shadow .15s;
+      transition:
+        background 0.15s,
+        border-color 0.15s,
+        box-shadow 0.15s;
       text-align: left;
       min-width: 0;
       flex: 1;
 
       &:hover:not(:disabled) {
-        background: rgba(200,160,60,.14);
-        border-color: rgba(200,160,60,.55);
-        box-shadow: 0 0 12px rgba(200,160,60,.2);
+        background: rgba(200, 160, 60, 0.14);
+        border-color: rgba(200, 160, 60, 0.55);
+        box-shadow: 0 0 12px rgba(200, 160, 60, 0.2);
       }
 
       &--active {
-        background: rgba(180,100,20,.25) !important;
-        border-color: rgba(210,130,40,.7) !important;
-        box-shadow: 0 0 14px rgba(200,120,30,.3) !important;
+        background: rgba(180, 100, 20, 0.25) !important;
+        border-color: rgba(210, 130, 40, 0.7) !important;
+        box-shadow: 0 0 14px rgba(200, 120, 30, 0.3) !important;
 
-        .sd-btn-label { color: #f0d080 !important; }
-        .sd-btn-icon { color: #f0c060 !important; }
+        .sd-btn-label {
+          color: #f0d080 !important;
+        }
+        .sd-btn-icon {
+          color: #f0c060 !important;
+        }
       }
 
       &--wide {
@@ -404,7 +415,7 @@ export interface SettingsDialogData {
       }
 
       &:disabled {
-        opacity: .45;
+        opacity: 0.45;
         cursor: not-allowed;
       }
     }
@@ -413,43 +424,65 @@ export interface SettingsDialogData {
       font-size: 20px;
       width: 20px;
       height: 20px;
-      color: rgba(200,160,60,.6);
+      color: rgba(200, 160, 60, 0.6);
       flex-shrink: 0;
-      transition: color .15s;
+      transition: color 0.15s;
     }
 
     /* ── Theme button icon colours ─────────────────────────── */
-    .sd-icon--light  { color: rgba(240, 200, 80, .75); }
-    .sd-icon--dark   { color: rgba(210, 150, 40, .7);  }
-    .sd-icon--sirien { color: rgba(140, 15,  15, .9);  }
-    .sd-icon--night  { color: rgba(80,  130, 210, .8); }
+    .sd-icon--light {
+      color: rgba(240, 200, 80, 0.75);
+    }
+    .sd-icon--dark {
+      color: rgba(210, 150, 40, 0.7);
+    }
+    .sd-icon--sirien {
+      color: rgba(140, 15, 15, 0.9);
+    }
+    .sd-icon--night {
+      color: rgba(80, 130, 210, 0.8);
+    }
 
-    .sd-btn--active .sd-icon--dark   { color: #f0c060 !important; }
-    .sd-btn--active .sd-icon--sirien { color: #c02020 !important; }
-    .sd-btn--active .sd-icon--night  { color: #7ab0f0 !important; }
+    .sd-btn--active .sd-icon--dark {
+      color: #f0c060 !important;
+    }
+    .sd-btn--active .sd-icon--sirien {
+      color: #c02020 !important;
+    }
+    .sd-btn--active .sd-icon--night {
+      color: #7ab0f0 !important;
+    }
 
     /* Tmavé active accent — warm amber */
     .sd-btn.sd-btn--theme:nth-child(2).sd-btn--active {
-      background: rgba(160, 100, 10, .28) !important;
-      border-color: rgba(220, 150, 40, .75) !important;
-      box-shadow: 0 0 14px rgba(200, 130, 20, .3) !important;
-      .sd-btn-label { color: #f5cc70 !important; }
+      background: rgba(160, 100, 10, 0.28) !important;
+      border-color: rgba(220, 150, 40, 0.75) !important;
+      box-shadow: 0 0 14px rgba(200, 130, 20, 0.3) !important;
+      .sd-btn-label {
+        color: #f5cc70 !important;
+      }
     }
 
     /* Sirien active accent — blood red on charcoal */
     .sd-btn.sd-btn--theme:nth-child(3).sd-btn--active {
-      background: rgba(40, 40, 40, .92) !important;
-      border-color: rgba(140, 15,  15, .8) !important;
-      box-shadow: 0 0 16px rgba(140, 15,  15, .45), inset 0 0 8px rgba(100, 8, 8, .25) !important;
-      .sd-btn-label { color: #c84040 !important; }
+      background: rgba(40, 40, 40, 0.92) !important;
+      border-color: rgba(140, 15, 15, 0.8) !important;
+      box-shadow:
+        0 0 16px rgba(140, 15, 15, 0.45),
+        inset 0 0 8px rgba(100, 8, 8, 0.25) !important;
+      .sd-btn-label {
+        color: #c84040 !important;
+      }
     }
 
     /* Noční active accent — steel blue */
     .sd-btn.sd-btn--theme:nth-child(4).sd-btn--active {
-      background: rgba(15,  50,  130, .32) !important;
-      border-color: rgba(70,  130, 220, .75) !important;
-      box-shadow: 0 0 14px rgba(50,  110, 200, .35) !important;
-      .sd-btn-label { color: #90c0f8 !important; }
+      background: rgba(15, 50, 130, 0.32) !important;
+      border-color: rgba(70, 130, 220, 0.75) !important;
+      box-shadow: 0 0 14px rgba(50, 110, 200, 0.35) !important;
+      .sd-btn-label {
+        color: #90c0f8 !important;
+      }
     }
 
     .sd-btn-text {
@@ -462,24 +495,28 @@ export interface SettingsDialogData {
     .sd-btn-label {
       font-family: sans-serif;
       font-size: 12px;
-      letter-spacing: .06em;
+      letter-spacing: 0.06em;
       color: #c8bfb0;
-      transition: color .15s;
+      transition: color 0.15s;
       white-space: nowrap;
     }
 
     .sd-btn-sub {
       font-family: sans-serif;
       font-size: 10px;
-      color: rgba(180,160,130,.45);
-      letter-spacing: .04em;
+      color: rgba(180, 160, 130, 0.45);
+      letter-spacing: 0.04em;
       white-space: normal;
       line-height: 1.3;
     }
 
     .sd-btn:hover:not(:disabled) {
-      .sd-btn-label { color: #e8d5a0; }
-      .sd-btn-icon { color: rgba(200,160,60,.9); }
+      .sd-btn-label {
+        color: #e8d5a0;
+      }
+      .sd-btn-icon {
+        color: rgba(200, 160, 60, 0.9);
+      }
     }
 
     /* ── Keyboard shortcut rows ────────────────────────────── */
@@ -488,9 +525,9 @@ export interface SettingsDialogData {
       align-items: center;
       gap: 12px;
       padding: 8px 12px;
-      border: 1px solid rgba(200,160,60,.15);
+      border: 1px solid rgba(200, 160, 60, 0.15);
       border-radius: 7px;
-      background: rgba(200,160,60,.04);
+      background: rgba(200, 160, 60, 0.04);
     }
 
     .sd-shortcut-keys {
@@ -503,34 +540,34 @@ export interface SettingsDialogData {
 
     .sd-shortcut-sep {
       font-size: 10px;
-      color: rgba(200,160,60,.35);
+      color: rgba(200, 160, 60, 0.35);
       padding: 0 1px;
     }
 
     .sd-shortcut-slash {
       font-size: 12px;
-      color: rgba(200,160,60,.25);
+      color: rgba(200, 160, 60, 0.25);
       padding: 0 4px;
     }
 
     kbd {
       font-size: 10px;
       padding: 2px 6px;
-      border: 1px solid rgba(200,160,60,.35);
+      border: 1px solid rgba(200, 160, 60, 0.35);
       border-bottom-width: 2px;
       border-radius: 4px;
-      background: rgba(200,160,60,.08);
-      color: rgba(200,160,60,.75);
+      background: rgba(200, 160, 60, 0.08);
+      color: rgba(200, 160, 60, 0.75);
       font-family: monospace;
-      letter-spacing: .03em;
+      letter-spacing: 0.03em;
       white-space: nowrap;
     }
 
     .sd-shortcut-desc {
       font-family: sans-serif;
       font-size: 11px;
-      color: rgba(180,160,130,.6);
-      letter-spacing: .04em;
+      color: rgba(180, 160, 130, 0.6);
+      letter-spacing: 0.04em;
       line-height: 1.3;
     }
 
@@ -547,12 +584,12 @@ export interface SettingsDialogData {
     .sd-gesture-swipe {
       font-size: 10px;
       font-family: monospace;
-      letter-spacing: .04em;
+      letter-spacing: 0.04em;
       padding: 2px 6px;
-      border: 1px solid rgba(200,160,60,.3);
+      border: 1px solid rgba(200, 160, 60, 0.3);
       border-radius: 4px;
-      background: rgba(200,160,60,.07);
-      color: rgba(200,160,60,.7);
+      background: rgba(200, 160, 60, 0.07);
+      color: rgba(200, 160, 60, 0.7);
       white-space: nowrap;
     }
 
@@ -562,16 +599,16 @@ export interface SettingsDialogData {
       align-items: flex-start;
       gap: 10px;
       padding: 10px 12px;
-      border: 1px solid rgba(140, 15, 15, .25);
+      border: 1px solid rgba(140, 15, 15, 0.25);
       border-radius: 7px;
-      background: rgba(40, 40, 40, .55);
+      background: rgba(40, 40, 40, 0.55);
     }
 
     .sd-credits-icon {
       font-size: 16px;
       width: 16px;
       height: 16px;
-      color: rgba(140, 15, 15, .8);
+      color: rgba(140, 15, 15, 0.8);
       flex-shrink: 0;
       margin-top: 1px;
     }
@@ -579,16 +616,16 @@ export interface SettingsDialogData {
     .sd-credits-text {
       font-family: sans-serif;
       font-size: 11px;
-      color: rgba(180, 155, 130, .65);
-      letter-spacing: .03em;
+      color: rgba(180, 155, 130, 0.65);
+      letter-spacing: 0.03em;
       line-height: 1.5;
     }
 
     .sd-credit-name {
       font-family: sans-serif;
       font-size: 11px;
-      letter-spacing: .06em;
-      color: rgba(200, 50, 50, .85);
+      letter-spacing: 0.06em;
+      color: rgba(200, 50, 50, 0.85);
       padding: 0 2px;
     }
 
@@ -603,21 +640,25 @@ export interface SettingsDialogData {
       gap: 6px;
       flex: 1;
       padding: 8px 12px;
-      border: 1px solid rgba(140, 15, 15, .2);
+      border: 1px solid rgba(140, 15, 15, 0.2);
       border-radius: 7px;
-      background: rgba(40, 40, 40, .4);
-      color: rgba(180, 60, 60, .8);
+      background: rgba(40, 40, 40, 0.4);
+      color: rgba(180, 60, 60, 0.8);
       text-decoration: none;
       font-size: 11px;
       font-family: sans-serif;
-      letter-spacing: .06em;
-      transition: background .15s, border-color .15s, color .15s, box-shadow .15s;
+      letter-spacing: 0.06em;
+      transition:
+        background 0.15s,
+        border-color 0.15s,
+        color 0.15s,
+        box-shadow 0.15s;
 
       &:hover {
-        background: rgba(40, 40, 40, .8);
-        border-color: rgba(140, 15, 15, .6);
+        background: rgba(40, 40, 40, 0.8);
+        border-color: rgba(140, 15, 15, 0.6);
         color: rgba(200, 80, 80, 1);
-        box-shadow: 0 0 10px rgba(140, 15, 15, .25);
+        box-shadow: 0 0 10px rgba(140, 15, 15, 0.25);
       }
     }
 
@@ -636,27 +677,27 @@ export interface SettingsDialogData {
       justify-content: flex-end;
       gap: 8px;
       padding: 8px 16px;
-      border-top: 1px solid rgba(200,160,60,.1);
-      background: rgba(200,160,60,.02);
+      border-top: 1px solid rgba(200, 160, 60, 0.1);
+      background: rgba(200, 160, 60, 0.02);
     }
 
     .sd-version-label {
       font-family: sans-serif;
       font-size: 10px;
-      letter-spacing: .1em;
-      color: rgba(200,160,60,.25);
+      letter-spacing: 0.1em;
+      color: rgba(200, 160, 60, 0.25);
       text-transform: uppercase;
     }
 
     .sd-version-badge {
       font-size: 10px;
       font-family: monospace;
-      letter-spacing: .08em;
-      color: rgba(200,160,60,.45);
+      letter-spacing: 0.08em;
+      color: rgba(200, 160, 60, 0.45);
       padding: 1px 6px;
-      border: 1px solid rgba(200,160,60,.2);
+      border: 1px solid rgba(200, 160, 60, 0.2);
       border-radius: 4px;
-      background: rgba(200,160,60,.05);
+      background: rgba(200, 160, 60, 0.05);
     }
   `,
 })
@@ -667,7 +708,6 @@ export class SettingsDialogComponent {
   readonly sheetTheme = inject(SheetThemeService);
   readonly data: SettingsDialogData = inject(MAT_DIALOG_DATA);
   private readonly dialogRef = inject(MatDialogRef<SettingsDialogComponent>);
-
 
   close(): void {
     this.dialogRef.close();

--- a/src/app/settings-dialog.component.ts
+++ b/src/app/settings-dialog.component.ts
@@ -244,16 +244,8 @@ export interface SettingsDialogData {
       max-width: 760px;
 
       &::before {
-        content: '◆';
-        position: absolute;
-        top: -7px; left: 50%;
-        transform: translateX(-50%);
-        font-size: 9px;
-        color: rgba(200,160,60,.6);
-        background: rgba(10,6,20,1);
-        padding: 0 6px;
-        pointer-events: none;
-        z-index: 2;
+        content: '';
+        display: none;
       }
     }
 

--- a/src/app/settings-dialog.component.ts
+++ b/src/app/settings-dialog.component.ts
@@ -35,7 +35,7 @@ export interface SettingsDialogData {
         <div class="sd-col-panel">
 
         <!-- Theme section -->
-        <div class="sd-section">
+        <div class="sd-section u-mb-6">
           <div class="sd-section-label">Téma karet</div>
           <div class="sd-theme-grid">
             <button
@@ -77,11 +77,11 @@ export interface SettingsDialogData {
           </div>
         </div>
 
-        <div class="sd-divider"></div>
+<!--        <div class="sd-divider"></div>-->
 
         <!-- Page layout section -->
         <div class="sd-section">
-          <div class="sd-section-label">Rozvržení stránek karty</div>
+          <div class="sd-section-label">Rozvržení stránek</div>
           <div class="sd-col">
             <button
               type="button"
@@ -89,7 +89,7 @@ export interface SettingsDialogData {
               [class.sd-btn--active]="!sheetTheme.spellsFirst()"
               (click)="sheetTheme.spellsFirst() && sheetTheme.toggleSpellsFirst()"
             >
-              <mat-icon class="sd-btn-icon">format_list_numbered</mat-icon>
+<!--              <mat-icon class="sd-btn-icon">format_list_numbered</mat-icon>-->
               <div class="sd-btn-text">
                 <span class="sd-btn-label">Výchozí pořadí</span>
                 <span class="sd-btn-sub">Str. 2 – Vzhled &amp; popis · str. 3 – Kouzla</span>
@@ -101,7 +101,7 @@ export interface SettingsDialogData {
               [class.sd-btn--active]="sheetTheme.spellsFirst()"
               (click)="!sheetTheme.spellsFirst() && sheetTheme.toggleSpellsFirst()"
             >
-              <mat-icon class="sd-btn-icon">auto_fix_high</mat-icon>
+<!--              <mat-icon class="sd-btn-icon">auto_fix_high</mat-icon>-->
               <div class="sd-btn-text">
                 <span class="sd-btn-label">Kouzla napřed</span>
                 <span class="sd-btn-sub">Str. 2 – Kouzla · str. 3 – Vzhled &amp; popis</span>
@@ -119,7 +119,7 @@ export interface SettingsDialogData {
         <div class="sd-col-panel">
 
         <!-- Export section -->
-        <div class="sd-section">
+        <div class="sd-section u-mb-6">
           <div class="sd-section-label">Záloha &amp; export <span style="color: red;">(experimentální)</span></div>
           <div class="sd-col">
             <button
@@ -150,10 +150,10 @@ export interface SettingsDialogData {
           </div>
         </div>
 
-        <div class="sd-divider"></div>
+<!--        <div class="sd-divider"></div>-->
 
         <!-- Keyboard shortcuts section -->
-        <div class="sd-section">
+        <div class="sd-section u-mb-6">
           <div class="sd-section-label">Klávesové zkratky &amp; gesta</div>
           <div class="sd-col">
             <div class="sd-shortcut-row">
@@ -172,32 +172,31 @@ export interface SettingsDialogData {
             </div>
             <div class="sd-shortcut-row">
               <div class="sd-shortcut-keys sd-shortcut-keys--gesture">
-                <span class="sd-gesture-icon">✌️</span>
-                <span class="sd-gesture-swipe">2× swipe ←</span>
-                <span class="sd-shortcut-slash">/</span>
-                <span class="sd-gesture-swipe">2× swipe →</span>
+                <span class="sd-gesture-swipe">swipe 2 prsty doprava/doleva</span>
+<!--                <span class="sd-shortcut-slash">/</span>-->
+<!--                <span class="sd-gesture-swipe">2× swipe →</span>-->
               </div>
-              <span class="sd-shortcut-desc">Přepínání záložek (dvěma prsty)</span>
+              <span class="sd-shortcut-desc">Přepínání záložek</span>
             </div>
           </div>
         </div>
 
-        <div class="sd-divider"></div>
+<!--        <div class="sd-divider"></div>-->
 
         <!-- Credits section -->
         <div class="sd-section">
           <div class="sd-section-label">Poděkování</div>
           <div class="sd-col">
-            <div class="sd-credits-row">
-              <mat-icon class="sd-credits-icon">auto_awesome</mat-icon>
-              <span class="sd-credits-text">
-                Speciální poděkování
-                <span class="sd-credit-name">&#64;Sirien</span>
-                a
-                <span class="sd-credit-name">&#64;Dukolm</span>
-                za jejich příspěvky a podporu projektu. A spoustě dalších z J&D komunity.
-              </span>
-            </div>
+<!--            <div class="sd-credits-row">-->
+<!--              <mat-icon class="sd-credits-icon">auto_awesome</mat-icon>-->
+<!--              <span class="sd-credits-text">-->
+<!--                Speciální poděkování-->
+<!--                <span class="sd-credit-name">&#64;Sirien</span>-->
+<!--                a-->
+<!--                <span class="sd-credit-name">&#64;Dukolm</span>-->
+<!--                za jejich příspěvky a podporu projektu. A spoustě dalších z J&D komunity.-->
+<!--              </span>-->
+<!--            </div>-->
             <div class="sd-credits-links">
               <a
                 href="https://www.jeskyneadraci.cz/"

--- a/src/app/settings-dialog.component.ts
+++ b/src/app/settings-dialog.component.ts
@@ -172,12 +172,12 @@ export interface SettingsDialogData {
             </div>
             <div class="sd-shortcut-row">
               <div class="sd-shortcut-keys sd-shortcut-keys--gesture">
-                <span class="sd-gesture-icon">👆</span>
-                <span class="sd-gesture-swipe">swipe ←</span>
+                <span class="sd-gesture-icon">✌️</span>
+                <span class="sd-gesture-swipe">2× swipe ←</span>
                 <span class="sd-shortcut-slash">/</span>
-                <span class="sd-gesture-swipe">swipe →</span>
+                <span class="sd-gesture-swipe">2× swipe →</span>
               </div>
-              <span class="sd-shortcut-desc">Přepínání záložek (dotyková gesta)</span>
+              <span class="sd-shortcut-desc">Přepínání záložek (dvěma prsty)</span>
             </div>
           </div>
         </div>

--- a/src/app/settings-dialog.component.ts
+++ b/src/app/settings-dialog.component.ts
@@ -236,12 +236,16 @@ export interface SettingsDialogData {
     /* ── Panel ─────────────────────────────────────────────── */
     .sd-panel {
       background:
-        linear-gradient(180deg, rgba(10,6,20,.99) 0%, rgba(18,12,28,.99) 100%);
+        linear-gradient(180deg, rgba(14,11,9,.98) 0%, rgba(22,17,13,.99) 100%);
       border: 1px solid rgba(200,160,60,.4);
       border-radius: 10px;
       overflow: hidden;
       min-width: 320px;
       max-width: 760px;
+      display: flex;
+      flex-direction: column;
+      height: auto;
+      max-height: 90vh;
 
       &::before {
         content: '';
@@ -305,6 +309,8 @@ export interface SettingsDialogData {
       grid-template-columns: 1fr auto 1fr;
       gap: 0;
       align-items: start;
+      overflow-y: auto;
+      flex: 1;
     }
 
     /* ── Two-column panels ─────────────────────────────────── */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -516,10 +516,11 @@ mat-sidenav-content {
 
 .cp-dialog-panel .mdc-dialog__surface {
   background: transparent !important;
-  box-shadow: 0 24px 80px rgba(0,0,0,.85), 0 0 0 1px rgba(200,160,60,.2) !important;
+  box-shadow: 0 24px 80px rgba(0,0,0,.85) !important;
   border-radius: 12px !important;
-  overflow: visible !important;
+  overflow: hidden !important;
   height: auto !important;
+  width: min(580px, 96vw) !important;
 }
 
 .cp-dialog-panel {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -200,6 +200,16 @@ mat-sidenav-content {
   transition: background .15s, border-color .15s, color .15s;
   font-family: sans-serif;
   white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+
+  mat-icon, .mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+  }
 
   &:hover  { background: rgba(200,160,60,.15); color: #d4c9a0; border-color: rgba(200,160,60,.4); }
   &.active { background: rgba(200,160,60,.25); color: #e8c96a; border-color: rgba(200,160,60,.6); }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,7 +17,7 @@
 
 body {
   margin: 0;
-  background-color: #0a0710;
+  background-color: #080504;
 }
 
 html,
@@ -37,11 +37,11 @@ body {
 }
 
 :root {
-  --background: hsl(270, 20%, 8%);
-  --background-gradient: hsl(280, 25%, 12%);
+  --background: hsl(0, 12%, 7%);
+  --background-gradient: hsl(0, 10%, 10%);
   --border: hsl(40, 65%, 80%);
   --text: hsl(40, 70%, 85%);
-  --button-hover: hsl(280, 25%, 12%);
+  --button-hover: hsl(0, 10%, 10%);
   --primary-color: #b84949;
 
   --mat-sys-primary: rgb(168, 58, 58);
@@ -67,7 +67,7 @@ body {
     padding: 14px 18px !important;
     color: #e8c96a !important;
     background:
-      linear-gradient(90deg, rgba(8,5,16,.98) 0%, rgba(22,15,38,.98) 50%, rgba(8,5,16,.98) 100%) !important;
+      linear-gradient(90deg, rgba(8,4,4,.98) 0%, rgba(20,10,8,.98) 50%, rgba(8,4,4,.98) 100%) !important;
     border-bottom: 1px solid rgba(200,160,60,.35) !important;
     text-shadow: 0 0 12px rgba(200,160,60,.4);
     position: relative;
@@ -205,7 +205,7 @@ mat-sidenav-content {
 // ════════════════════════════════════════════════════════════════
 mat-toolbar.toolbar {
   background:
-    linear-gradient(90deg, rgba(6,4,12,.98) 0%, rgba(16,11,26,.98) 50%, rgba(6,4,12,.98) 100%) !important;
+    linear-gradient(90deg, rgba(8,4,4,.98) 0%, rgba(16,8,6,.98) 50%, rgba(8,4,4,.98) 100%) !important;
   border-bottom: 1px solid rgba(200,160,60,.3) !important;
   box-shadow: 0 2px 20px rgba(0,0,0,.7), 0 1px 0 rgba(200,160,60,.15) !important;
   color: #e0d4c0 !important;
@@ -228,14 +228,14 @@ mat-toolbar.toolbar {
 
 // Backdrop
 .cdk-overlay-backdrop.cdk-overlay-dark-backdrop {
-  background: rgba(4, 2, 10, 0.82) !important;
+  background: rgba(6, 3, 3, 0.82) !important;
   backdrop-filter: blur(2px);
 }
 
 // Dialog surface
 .mat-mdc-dialog-surface {
   background:
-    linear-gradient(180deg, rgba(10,7,20,.99) 0%, rgba(16,11,28,.99) 100%) !important;
+    linear-gradient(180deg, rgba(10,5,4,.99) 0%, rgba(16,8,6,.99) 100%) !important;
   border: 1px solid rgba(200,160,60,.3) !important;
   border-radius: 10px !important;
   box-shadow:
@@ -284,7 +284,7 @@ mat-dialog-content.dialog-content,
 }
 
 .sd-dialog-backdrop {
-  background: rgba(4,2,10,.75) !important;
+  background: rgba(6,3,3,.75) !important;
   backdrop-filter: blur(3px);
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -61,78 +61,61 @@ body {
     align-items: center;
     justify-content: space-between;
     gap: var(--spacing-2);
-    font-size: 18px !important;
-    font-family: 'Mikadan', sans-serif !important;
+    font-size: 14px !important;
+    font-family: sans-serif !important;
     letter-spacing: .06em;
-    padding: 14px 18px !important;
-    color: #e8c96a !important;
+    padding: 8px 14px !important;
+    color: #e0d4c0 !important;
     background:
-      linear-gradient(90deg, rgba(8,4,3,.98) 0%, rgba(14,8,5,.98) 50%, rgba(8,4,3,.98) 100%) !important;
-    border-bottom: 1px solid rgba(200,160,60,.35) !important;
-    text-shadow: 0 0 12px rgba(200,160,60,.4);
+      linear-gradient(90deg, rgba(12,10,8,.98) 0%, rgba(20,16,13,.98) 50%, rgba(12,10,8,.98) 100%) !important;
+    border-bottom: 1px solid rgba(200,160,60,.25) !important;
     position: relative;
 
-    // bottom gold rule line
+    // bottom gold shimmer
     &::after {
       content: '';
       position: absolute;
       bottom: -1px; left: 10%; right: 10%;
       height: 1px;
-      background: linear-gradient(90deg, transparent, rgba(200,160,60,.6), transparent);
+      background: linear-gradient(90deg, transparent, rgba(200,160,60,.45), transparent);
     }
 
-    // ── DnD close button — wax seal style ────────────────────
+    // ── Simple close button ────────────────────────────────────
     button {
-      position: relative !important;
-      width: 34px !important;
-      height: 34px !important;
-      min-width: 34px !important;
+      width: 26px !important;
+      height: 26px !important;
+      min-width: 26px !important;
       padding: 0 !important;
       flex-shrink: 0;
+      background: transparent !important;
+      border: 1px solid rgba(200,160,60,.25) !important;
+      border-radius: 4px !important;
+      color: rgba(200,160,60,.55) !important;
+      cursor: pointer;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      transition: background .15s, border-color .15s, color .15s !important;
 
-      // hide Material ripple / state layer noise
       .mat-mdc-button-ripple,
       .mat-mdc-button-persistent-ripple,
       .mdc-button__ripple { display: none !important; }
 
-      // seal base — round dark disc
-      &::before {
-        content: '✕';
-        position: absolute !important;
-        inset: 0 !important;
-        display: flex !important;
-        align-items: center !important;
-        justify-content: center !important;
-        border-radius: 50% !important;
-        background: radial-gradient(circle at 38% 32%, rgba(60,20,20,.95), rgba(30,8,8,.98)) !important;
-        border: 1.5px solid rgba(200,80,60,.45) !important;
-        box-shadow:
-          0 0 0 1px rgba(200,160,60,.15),
-          0 2px 8px rgba(0,0,0,.7),
-          inset 0 1px 0 rgba(255,160,120,.08) !important;
-        color: rgba(200,100,80,.85) !important;
-        font-size: 13px !important;
-        font-family: sans-serif !important;
-        line-height: 1 !important;
-        transition: background .18s, border-color .18s, box-shadow .18s, transform .14s !important;
-        z-index: 1;
-        pointer-events: none;
-      }
-
-      // hide the actual mat-icon — our ::before renders the ✕
+      // Show icon normally
       mat-icon, .mat-icon {
-        opacity: 0 !important;
+        font-size: 16px !important;
+        width: 16px !important;
+        height: 16px !important;
+        opacity: 1 !important;
+        color: inherit !important;
       }
 
-      &:hover::before {
-        background: radial-gradient(circle at 38% 32%, rgba(140,30,20,1), rgba(80,10,10,1)) !important;
-        border-color: rgba(220,80,60,.8) !important;
-        box-shadow:
-          0 0 0 1px rgba(200,160,60,.25),
-          0 0 14px rgba(200,60,40,.4),
-          inset 0 1px 0 rgba(255,160,120,.15) !important;
-        color: #ff8070 !important;
-        transform: scale(1.12) !important;
+      &::before { display: none !important; }
+
+      &:hover {
+        background: rgba(200,160,60,.1) !important;
+        border-color: rgba(200,160,60,.5) !important;
+        color: #e8c96a !important;
       }
     }
   }
@@ -235,7 +218,7 @@ mat-toolbar.toolbar {
 // Dialog surface
 .mat-mdc-dialog-surface {
   background:
-    linear-gradient(180deg, rgba(10,5,4,.99) 0%, rgba(16,8,6,.99) 100%) !important;
+    linear-gradient(180deg, rgba(12,10,8,.99) 0%, rgba(18,15,12,.99) 100%) !important;
   border: 1px solid rgba(200,160,60,.3) !important;
   border-radius: 10px !important;
   box-shadow:

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -67,7 +67,7 @@ body {
     padding: 14px 18px !important;
     color: #e8c96a !important;
     background:
-      linear-gradient(90deg, rgba(8,4,4,.98) 0%, rgba(20,10,8,.98) 50%, rgba(8,4,4,.98) 100%) !important;
+      linear-gradient(90deg, rgba(14,2,2,.98) 0%, rgba(24,4,4,.98) 50%, rgba(14,2,2,.98) 100%) !important;
     border-bottom: 1px solid rgba(200,160,60,.35) !important;
     text-shadow: 0 0 12px rgba(200,160,60,.4);
     position: relative;
@@ -205,7 +205,7 @@ mat-sidenav-content {
 // ════════════════════════════════════════════════════════════════
 mat-toolbar.toolbar {
   background:
-    linear-gradient(90deg, rgba(8,4,4,.98) 0%, rgba(16,8,6,.98) 50%, rgba(8,4,4,.98) 100%) !important;
+    linear-gradient(90deg, rgba(14,2,2,.98) 0%, rgba(22,4,4,.98) 50%, rgba(14,2,2,.98) 100%) !important;
   border-bottom: 1px solid rgba(200,160,60,.3) !important;
   box-shadow: 0 2px 20px rgba(0,0,0,.7), 0 1px 0 rgba(200,160,60,.15) !important;
   color: #e0d4c0 !important;
@@ -235,7 +235,7 @@ mat-toolbar.toolbar {
 // Dialog surface
 .mat-mdc-dialog-surface {
   background:
-    linear-gradient(180deg, rgba(10,5,4,.99) 0%, rgba(16,8,6,.99) 100%) !important;
+    linear-gradient(180deg, rgba(14,2,2,.99) 0%, rgba(20,4,4,.99) 100%) !important;
   border: 1px solid rgba(200,160,60,.3) !important;
   border-radius: 10px !important;
   box-shadow:

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -67,7 +67,7 @@ body {
     padding: 14px 18px !important;
     color: #e8c96a !important;
     background:
-      linear-gradient(90deg, rgba(14,2,2,.98) 0%, rgba(24,4,4,.98) 50%, rgba(14,2,2,.98) 100%) !important;
+      linear-gradient(90deg, rgba(8,4,3,.98) 0%, rgba(14,8,5,.98) 50%, rgba(8,4,3,.98) 100%) !important;
     border-bottom: 1px solid rgba(200,160,60,.35) !important;
     text-shadow: 0 0 12px rgba(200,160,60,.4);
     position: relative;
@@ -205,7 +205,7 @@ mat-sidenav-content {
 // ════════════════════════════════════════════════════════════════
 mat-toolbar.toolbar {
   background:
-    linear-gradient(90deg, rgba(14,2,2,.98) 0%, rgba(22,4,4,.98) 50%, rgba(14,2,2,.98) 100%) !important;
+    linear-gradient(90deg, rgba(12,10,8,.98) 0%, rgba(20,16,13,.98) 50%, rgba(12,10,8,.98) 100%) !important;
   border-bottom: 1px solid rgba(200,160,60,.3) !important;
   box-shadow: 0 2px 20px rgba(0,0,0,.7), 0 1px 0 rgba(200,160,60,.15) !important;
   color: #e0d4c0 !important;
@@ -228,14 +228,14 @@ mat-toolbar.toolbar {
 
 // Backdrop
 .cdk-overlay-backdrop.cdk-overlay-dark-backdrop {
-  background: rgba(6, 3, 3, 0.82) !important;
+  background: rgba(4, 3, 2, 0.82) !important;
   backdrop-filter: blur(2px);
 }
 
 // Dialog surface
 .mat-mdc-dialog-surface {
   background:
-    linear-gradient(180deg, rgba(14,2,2,.99) 0%, rgba(20,4,4,.99) 100%) !important;
+    linear-gradient(180deg, rgba(10,5,4,.99) 0%, rgba(16,8,6,.99) 100%) !important;
   border: 1px solid rgba(200,160,60,.3) !important;
   border-radius: 10px !important;
   box-shadow:

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -260,19 +260,6 @@ mat-toolbar.toolbar {
     inset 0 1px 0 rgba(255,220,100,.07) !important;
   overflow: hidden !important;
 
-  // Corner gem decorators
-  &::before,
-  &::after {
-    content: '◆';
-    position: absolute;
-    color: rgba(200,160,60,.5);
-    font-size: 9px;
-    line-height: 1;
-    pointer-events: none;
-    z-index: 10;
-  }
-  &::before { top: 6px; left: 8px; }
-  &::after  { top: 6px; right: 8px; }
 }
 
 // mat-dialog-content scroll area

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -184,7 +184,40 @@ mat-sidenav-content {
 }
 
 // ════════════════════════════════════════════════════════════════
+// DND FILTER BUTTON — unified filter/chip style used across all tabs
+// (Kouzla, Monstra, Lektvary and any future filter row)
+// Used as: .pt-filter-btn  (canonical class, also aliased as .dnd-filter-btn)
+// ════════════════════════════════════════════════════════════════
+.pt-filter-btn,
+.dnd-filter-btn {
+  background: rgba(200,160,60,.08);
+  border: 1px solid rgba(200,160,60,.2);
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 11px;
+  color: #9a8a6a;
+  cursor: pointer;
+  transition: background .15s, border-color .15s, color .15s;
+  font-family: sans-serif;
+  white-space: nowrap;
+
+  &:hover  { background: rgba(200,160,60,.15); color: #d4c9a0; border-color: rgba(200,160,60,.4); }
+  &.active { background: rgba(200,160,60,.25); color: #e8c96a; border-color: rgba(200,160,60,.6); }
+}
+
+// CR / challenge-rating variant (red-orange tint)
+.pt-filter-btn--cr,
+.dnd-filter-btn--cr {
+  border-color: rgba(200,80,60,.3);
+  color: rgba(220,120,80,.6);
+
+  &:hover  { border-color: rgba(220,120,80,.6); color: #e8a070; background: rgba(200,80,60,.07); }
+  &.active { background: rgba(200,80,60,.18); border-color: rgba(220,120,80,.8); color: #f0a070; }
+}
+
+// ════════════════════════════════════════════════════════════════
 // TOOLBAR — D&D dark fantasy style
+
 // ════════════════════════════════════════════════════════════════
 mat-toolbar.toolbar {
   background:

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -272,18 +272,28 @@ mat-dialog-content.dialog-content,
 // ════════════════════════════════════════════════════════════════
 // SETTINGS DIALOG — zero padding, custom panel handles all styling
 // ════════════════════════════════════════════════════════════════
+.sd-dialog-panel .mat-mdc-dialog-container {
+  background: transparent !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  height: auto !important;
+  overflow: visible !important;
+}
+
 .sd-dialog-panel .mat-mdc-dialog-surface {
   padding: 0 !important;
   border: none !important;
   background: transparent !important;
   box-shadow: none !important;
   overflow: visible !important;
+  height: auto !important;
 
   &::before, &::after { display: none !important; }
 }
 
 .sd-dialog-panel {
   overflow: visible !important;
+  height: auto !important;
 }
 
 .sd-dialog-backdrop {
@@ -501,6 +511,7 @@ mat-sidenav-content {
   padding: 0 !important;
   border-radius: 12px !important;
   overflow: visible !important;
+  height: auto !important;
 }
 
 .cp-dialog-panel .mdc-dialog__surface {
@@ -508,6 +519,11 @@ mat-sidenav-content {
   box-shadow: 0 24px 80px rgba(0,0,0,.85), 0 0 0 1px rgba(200,160,60,.2) !important;
   border-radius: 12px !important;
   overflow: visible !important;
+  height: auto !important;
+}
+
+.cp-dialog-panel {
+  height: auto !important;
 }
 
 .cp-dialog-backdrop {


### PR DESCRIPTION
- wiki has custom wiki-sidenav which is not pushing content - which leads to better performance - especially on mobile devices. sidenav could be closed when clicked somewhere else
    - wiki is now much better for mobile/tablet devices - full width of content is used
    - scroll to particular header is fixed (`-70px` from top)
- release-notes updated accordingly
- color palette for top-bar and sidenav-menu changed, as well as for dialogs _(now not that ugly purple color)_
- remove useless headers from pages like Notes, Quests, etc - buttons aligned to right side particularly
- unification of all dialogs design - much simpler and better looking now
- unification of all switch-buttons _(see screen)_
- DM Quests cards improvements, removed imgs from input as well as from player's quests - DM Quests cards are now much simpler and easier to navigate
- graphical improvements for Settings and quick-nav dialogs
- States Of Player dialog graphical improvements
- useless paddings on pages removed, now there's much more space _(2nd screen bellow)_
- initiative tracker page _(for DM and player)_ improved - better simpler design, cards are fixed etc
- Story Events page improved - simpler design, cards design is also fixed
    - _labels_ through search dropdown - adding already existing labels into event
    - possibility to share events with other players
    - 2 tabs - custom events and shared events
- `Ctrl+S` works everywhere, shortcut for saving changes 
- buttons styles unified _(+add item btn, save btn, etc)_
- save snackbars has same text accross the whole app
- dropdown for Animal in group-sheet has dark theme - there was bug, items were not visible

<img width="562" height="98" alt="image" src="https://github.com/user-attachments/assets/1b55dbd1-bbde-4549-9cb3-43cac10a2379" />

padding fixed
<img width="1372" height="375" alt="image" src="https://github.com/user-attachments/assets/eaf42763-80fd-4eb8-b8f2-5ee6c6cebc3a" />

